### PR TITLE
Ensure reads wait for active writes

### DIFF
--- a/app/src/main/java/org/garret/perst/PinnedPersistent.java
+++ b/app/src/main/java/org/garret/perst/PinnedPersistent.java
@@ -14,8 +14,14 @@ import org.garret.perst.impl.StorageImpl;
  */
 public class PinnedPersistent implements IPersistent, ICloneable 
 { 
+    /**
+     * Load the object's state from storage.
+     * This call blocks if another thread currently holds a write lock
+     * on the object.
+     */
     public synchronized void load() {
-        if (oid != 0 && (state & RAW) != 0) { 
+        if (oid != 0 && (state & RAW) != 0) {
+            storage.checkReadLock(getOid());
             storage.loadObject(this);
         }
     }

--- a/app/src/main/java/org/garret/perst/Storage.java
+++ b/app/src/main/java/org/garret/perst/Storage.java
@@ -733,6 +733,15 @@ public interface Storage {
     public Object getObjectByOID(int oid);
 
     /**
+     * Ensure that reading an object is safe with respect to concurrent writes.
+     * If the object with the specified OID is currently write locked by another
+     * thread, this method blocks until the lock is released.
+     *
+     * @param oid object oid
+     */
+    public void checkReadLock(int oid);
+
+    /**
      * Explicitely make object peristent. Usually objects are made persistent
      * implicitlely using "persistency on reachability apporach", but this
      * method allows to do it explicitly. If object is already persistent, execution of


### PR DESCRIPTION
## Summary
- protect object reads by checking write-locks before loading or lookup
- add `checkReadLock` API and implement read wait logic in `StorageImpl`
- document that `PinnedPersistent.load()` may block if the object is being written

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a93b4a5a908330897e693eecebab53