### PR TITLE
feat: improve generic field indexes

### DIFF
--- a/app/src/main/java/org/garret/perst/Storage.java
+++ b/app/src/main/java/org/garret/perst/Storage.java
@@ -543,7 +543,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.UNSUPPORTED_INDEX_TYPE) exception if type of specified field is not supported by implementation
      */
-    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class type, String fieldName, boolean unique);
+    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class<T> type, String fieldName, boolean unique);
 
     /**
      * Create new field index optimized for access by element position.
@@ -555,7 +555,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.UNSUPPORTED_INDEX_TYPE) exception if type of specified field is not supported by implementation
      */
-    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class type, String fieldName, boolean unique, boolean caseInsensitive);
+    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class<T> type, String fieldName, boolean unique, boolean caseInsensitive);
 
     /**
      * Create new mutlifield index optimized for access by element position.
@@ -566,7 +566,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.UNSUPPORTED_INDEX_TYPE) exception if type of specified field is not supported by implementation
      */
-    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class type, String[] fieldNames, boolean unique);
+    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class<T> type, String[] fieldNames, boolean unique);
 
     /**
      * Create new mutlifield index optimized for access by element position.
@@ -578,7 +578,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.UNSUPPORTED_INDEX_TYPE) exception if type of specified field is not supported by implementation
      */
-    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class type, String[] fieldNames, boolean unique, boolean caseInsensitive);
+    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class<T> type, String[] fieldNames, boolean unique, boolean caseInsensitive);
 
      /**
      * Create new spatial index with integer coordinates

--- a/app/src/main/java/org/garret/perst/impl/RndBtreeFieldIndex.java
+++ b/app/src/main/java/org/garret/perst/impl/RndBtreeFieldIndex.java
@@ -8,7 +8,7 @@ class RndBtreeFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
     String className;
     String fieldName;
     long   autoincCount;
-    transient Class cls;
+    transient Class<T> cls;
     transient Field fld;
 
     RndBtreeFieldIndex() {}
@@ -31,11 +31,11 @@ class RndBtreeFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
 
     public void onLoad()
     {
-        cls = ClassDescriptor.loadClass(getStorage(), className);
+        cls = (Class<T>)ClassDescriptor.loadClass(getStorage(), className);
         locateField();
     }
 
-    RndBtreeFieldIndex(Class cls, String fieldName, boolean unique) {
+    RndBtreeFieldIndex(Class<T> cls, String fieldName, boolean unique) {
         this.cls = cls;
         this.unique = unique;
         this.fieldName = fieldName;
@@ -245,10 +245,10 @@ class RndBtreeFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
     }
 }
 
-class RndBtreeCaseInsensitiveFieldIndex<T> extends RndBtreeFieldIndex<T> {    
+class RndBtreeCaseInsensitiveFieldIndex<T> extends RndBtreeFieldIndex<T> {
     RndBtreeCaseInsensitiveFieldIndex() {}
 
-    RndBtreeCaseInsensitiveFieldIndex(Class cls, String fieldName, boolean unique) {
+    RndBtreeCaseInsensitiveFieldIndex(Class<T> cls, String fieldName, boolean unique) {
         super(cls, fieldName, unique);
     }
 

--- a/app/src/main/java/org/garret/perst/impl/RndBtreeMultiFieldIndex.java
+++ b/app/src/main/java/org/garret/perst/impl/RndBtreeMultiFieldIndex.java
@@ -9,12 +9,12 @@ class RndBtreeMultiFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
     String   className;
     String[] fieldName;
 
-    transient Class   cls;
+    transient Class<T>   cls;
     transient Field[] fld;
 
     RndBtreeMultiFieldIndex() {}
     
-    RndBtreeMultiFieldIndex(Class cls, String[] fieldName, boolean unique) {
+    RndBtreeMultiFieldIndex(Class<T> cls, String[] fieldName, boolean unique) {
         this.cls = cls;
         this.unique = unique;
         this.fieldName = fieldName;        
@@ -45,7 +45,7 @@ class RndBtreeMultiFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
 
     public void onLoad()
     {
-        cls = ClassDescriptor.loadClass(getStorage(), className);
+        cls = (Class<T>)ClassDescriptor.loadClass(getStorage(), className);
         locateFields();
     }
 
@@ -235,10 +235,10 @@ class RndBtreeMultiFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
     }
 }
 
-class RndBtreeCaseInsensitiveMultiFieldIndex<T> extends RndBtreeMultiFieldIndex<T> {    
+class RndBtreeCaseInsensitiveMultiFieldIndex<T> extends RndBtreeMultiFieldIndex<T> {
     RndBtreeCaseInsensitiveMultiFieldIndex() {}
 
-    RndBtreeCaseInsensitiveMultiFieldIndex(Class cls, String[] fieldNames, boolean unique) {
+    RndBtreeCaseInsensitiveMultiFieldIndex(Class<T> cls, String[] fieldNames, boolean unique) {
         super(cls, fieldNames, unique);
     }
 

--- a/app/src/main/java/org/garret/perst/impl/StorageImpl.java
+++ b/app/src/main/java/org/garret/perst/impl/StorageImpl.java
@@ -1995,11 +1995,11 @@ public class StorageImpl implements Storage {
     }
 
 
-    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class type, String fieldName, boolean unique) {
+    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class<T> type, String fieldName, boolean unique) {
         return this.<T>createRandomAccessFieldIndex(type, fieldName, unique, false);
     }
 
-    public synchronized <T> FieldIndex<T> createRandomAccessFieldIndex(Class type, String fieldName, boolean unique, boolean caseInsensitive) {
+    public synchronized <T> FieldIndex<T> createRandomAccessFieldIndex(Class<T> type, String fieldName, boolean unique, boolean caseInsensitive) {
         if (!opened) {
             throw new StorageError(StorageError.STORAGE_NOT_OPENED);
         }
@@ -2010,11 +2010,11 @@ public class StorageImpl implements Storage {
         return index;
     }
 
-    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class type, String[] fieldNames, boolean unique) {
+    public <T> FieldIndex<T> createRandomAccessFieldIndex(Class<T> type, String[] fieldNames, boolean unique) {
         return this.<T>createRandomAccessFieldIndex(type, fieldNames, unique, false);
     }
 
-    public synchronized <T> FieldIndex<T> createRandomAccessFieldIndex(Class type, String[] fieldNames, boolean unique, boolean caseInsensitive) {
+    public synchronized <T> FieldIndex<T> createRandomAccessFieldIndex(Class<T> type, String[] fieldNames, boolean unique, boolean caseInsensitive) {
         if (!opened) {
             throw new StorageError(StorageError.STORAGE_NOT_OPENED);
         }

--- a/tst/TestCompoundIndex.java
+++ b/tst/TestCompoundIndex.java
@@ -20,8 +20,8 @@ public class TestCompoundIndex {
             }
         }
         db.open("testcidx.dbs", pagePoolSize);
-        FieldIndex root = (FieldIndex)db.getRoot();
-        if (root == null) { 
+        FieldIndex<Record> root = (FieldIndex<Record>)db.getRoot();
+        if (root == null) {
             root = db.createFieldIndex(Record.class, new String[]{"intKey", "strKey"}, true);
             db.setRoot(root);
         }

--- a/tst/TestMaxOid.java
+++ b/tst/TestMaxOid.java
@@ -19,8 +19,8 @@ public class TestMaxOid {
         Storage db = StorageFactory.getInstance().createStorage();
         db.open("testmaxoid.dbs", pagePoolSize);
         int i;
-        FieldIndex root = (FieldIndex)db.getRoot();
-        if (root == null) { 
+        FieldIndex<Record> root = (FieldIndex<Record>)db.getRoot();
+        if (root == null) {
             root = db.createFieldIndex(Record.class, "key", true);
             db.setRoot(root);
         }

--- a/tst/TestRndIndex.java
+++ b/tst/TestRndIndex.java
@@ -15,8 +15,8 @@ public class TestRndIndex {
         Storage db = StorageFactory.getInstance().createStorage();
         db.open("testrnd.dbs", pagePoolSize);
             
-        FieldIndex root = (FieldIndex)db.getRoot();
-        if (root == null) { 
+        FieldIndex<Record> root = (FieldIndex<Record>)db.getRoot();
+        if (root == null) {
             root = db.createRandomAccessFieldIndex(Record.class, "i", true);
             db.setRoot(root);
         }


### PR DESCRIPTION
## Summary
- parameterize random-access field index factories with the indexed type
- use typed field index constructors and generics for index maps
- remove raw FieldIndex casts in tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a955300634833088b25bf786558121