### PR TITLE
Specify LinkImpl generic type

### DIFF
--- a/app/src/main/java/org/garret/perst/continuous/TableDescriptor.java
+++ b/app/src/main/java/org/garret/perst/continuous/TableDescriptor.java
@@ -302,9 +302,9 @@ class TableDescriptor extends Persistent implements Iterable<CVersionHistory>
             for (Field f : cloneableFields) {             
                 Object o = f.get(v);
                 if (o != null) { 
-                    if (o instanceof LinkImpl) { 
-                        o = new LinkImpl((StorageImpl)getStorage(), (Link)o, v);
-                    } else if (o instanceof ICloneable[]) { 
+                    if (o instanceof LinkImpl) {
+                        o = new LinkImpl<Object>((StorageImpl)getStorage(), (Link)o, v);
+                    } else if (o instanceof ICloneable[]) {
                         ICloneable[] arr = (ICloneable[])((Object[])o).clone();
                         for (int i = 0; i < arr.length; i++) { 
                             arr[i] = (ICloneable)arr[i].clone();

--- a/app/src/main/java/org/garret/perst/impl/StorageImpl.java
+++ b/app/src/main/java/org/garret/perst/impl/StorageImpl.java
@@ -3728,7 +3728,7 @@ public class StorageImpl implements Storage {
                             arr[j] = new PersistentStub(this, elemOid);
                         }
                     }
-                    val = new LinkImpl(this, arr, parent);
+                    val = new LinkImpl<Object>(this, arr, parent);
                     break;
                 }
             case ClassDescriptor.tpArrayOfByte:
@@ -4360,7 +4360,7 @@ public class StorageImpl implements Storage {
                                 arr[j] = new PersistentStub(this, elemOid);
                             }
                         }
-                        provider.set(f, obj, new LinkImpl(this, arr, parent));
+                        provider.set(f, obj, new LinkImpl<Object>(this, arr, parent));
                     }
                 }
             }

--- a/continuous/src/org/garret/perst/continuous/TableDescriptor.java
+++ b/continuous/src/org/garret/perst/continuous/TableDescriptor.java
@@ -302,9 +302,9 @@ class TableDescriptor extends Persistent implements Iterable<CVersionHistory>
             for (Field f : cloneableFields) {             
                 Object o = f.get(v);
                 if (o != null) { 
-                    if (o instanceof LinkImpl) { 
-                        o = new LinkImpl((StorageImpl)getStorage(), (Link)o, v);
-                    } else if (o instanceof ICloneable[]) { 
+                    if (o instanceof LinkImpl) {
+                        o = new LinkImpl<Object>((StorageImpl)getStorage(), (Link)o, v);
+                    } else if (o instanceof ICloneable[]) {
                         ICloneable[] arr = (ICloneable[])((Object[])o).clone();
                         for (int i = 0; i < arr.length; i++) { 
                             arr[i] = (ICloneable)arr[i].clone();


### PR DESCRIPTION
## Summary
- Replace raw `LinkImpl` instantiation with `LinkImpl<Object>` to avoid raw type use when deserializing links
- Parameterize cloned `LinkImpl` instances in TableDescriptor for type-safe assignments

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a95beb2c248330a76b3990467327f2