### PR TITLE
Parameterize collection casts in StorageImpl

### DIFF
--- a/app/src/main/java/org/garret/perst/impl/StorageImpl.java
+++ b/app/src/main/java/org/garret/perst/impl/StorageImpl.java
@@ -3867,7 +3867,8 @@ public class StorageImpl implements Storage {
                     if (desc.isCollection) {
                         int len = Bytes.unpack4(body, offs);
                         obj.offs = offs + 4;
-                        Collection collection = (Collection)val;
+                        @SuppressWarnings("unchecked")
+                        Collection<Object> collection = (Collection<Object>)val;
                         for (int i = 0; i < len; i++) {
                             collection.add(unswizzle(obj, Object.class, parent, recursiveLoading));
                         }
@@ -3875,7 +3876,8 @@ public class StorageImpl implements Storage {
                     } else if (desc.isMap) {
                         int len = Bytes.unpack4(body, offs);
                         obj.offs = offs + 4;
-                        Map map = (Map)val;
+                        @SuppressWarnings("unchecked")
+                        Map<Object,Object> map = (Map<Object,Object>)val;
                         for (int i = 0; i < len; i++) {
                             Object key = unswizzle(obj, Object.class, parent, recursiveLoading);
                             Object value = unswizzle(obj, Object.class, parent, recursiveLoading);


### PR DESCRIPTION
## Summary
- Use typed Collection and Map casts when deserializing value types
- Suppress unchecked cast warnings and update loops to add/put without raw types

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a95de238a48330996adcbcc9f17566