### PR TITLE
Use storage accessor for GraphNode links

### DIFF
--- a/app/src/main/java/biz/digitalindustry/db/graph/GraphNode.java
+++ b/app/src/main/java/biz/digitalindustry/db/graph/GraphNode.java
@@ -19,7 +19,7 @@ public class GraphNode extends Persistent {
         super(storage);                   // sets the storage field in superclass
         this.id = id;
         this.label = label;
-        outgoing = storage.createLink();  // returns LinkImpl
-        incoming = storage.createLink();
+        outgoing = getStorage().createLink();  // returns LinkImpl
+        incoming = getStorage().createLink();
     }
 }


### PR DESCRIPTION
## Summary
- Initialize GraphNode `outgoing` and `incoming` links using `getStorage()` to avoid accessing package-private fields.

## Testing
- `./gradlew test` *(fails: no suitable GraphNode constructor used in GraphDatabase)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4111fd908330bba63c0f40f76e35