### PR TITLE
Pass storage to GraphNode constructors

### DIFF
--- a/app/src/main/java/biz/digitalindustry/db/graph/GraphDatabase.java
+++ b/app/src/main/java/biz/digitalindustry/db/graph/GraphDatabase.java
@@ -23,7 +23,7 @@ public class GraphDatabase {
     }
 
     public GraphNode createNode(String id, String label) {
-        GraphNode node = new GraphNode(id, label);
+        GraphNode node = new GraphNode(db, id, label);
         ((Root) db.getRoot()).nodeIndex.put(node);  // only pass the object
         return node;
     }
@@ -54,7 +54,7 @@ public class GraphDatabase {
     protected GraphNode getOrCreateNode(String id) {
         GraphNode node = getNode(id);
         if (node == null) {
-            node = new GraphNode(id, null);
+            node = new GraphNode(db, id, null);
             ((Root) db.getRoot()).nodeIndex.put(node);
         }
         return node;


### PR DESCRIPTION
## Summary
- pass `db` to `GraphNode` in `createNode` and `getOrCreateNode`
- ensure all `GraphNode` instantiations provide the storage instance

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68aa41babb8883309c456785a7d987eb