### PR TITLE
Pass storage to GraphNode constructors

### DIFF
--- a/app/src/main/java/biz/digitalindustry/db/graph/GraphDatabase.java
+++ b/app/src/main/java/biz/digitalindustry/db/graph/GraphDatabase.java
@@ -23,7 +23,7 @@ public class GraphDatabase {
     }
 
     public GraphNode createNode(String id, String label) {
-        GraphNode node = new GraphNode(id, label);
+        GraphNode node = new GraphNode(db, id, label);
         ((Root) db.getRoot()).nodeIndex.put(node);  // only pass the object
         return node;
     }
@@ -54,7 +54,7 @@ public class GraphDatabase {
     protected GraphNode getOrCreateNode(String id) {
         GraphNode node = getNode(id);
         if (node == null) {
-            node = new GraphNode(id, null);
+            node = new GraphNode(db, id, null);
             ((Root) db.getRoot()).nodeIndex.put(node);
         }
         return node;

--- a/app/src/test/java/org/garret/perst/modes/ContinuousModeTest.java
+++ b/app/src/test/java/org/garret/perst/modes/ContinuousModeTest.java
@@ -16,7 +16,7 @@ public class ContinuousModeTest {
 
     @Test
     public void continuousIncrements() throws Exception {
-        File dbFile = new File(getClass().getClassLoader().getResource("continuous.dbs").toURI());
+        File dbFile = File.createTempFile("continuous", ".dbs");
         dbFile.delete();
         Storage storage = StorageFactory.getInstance().createStorage();
         storage.open(dbFile.getPath());

--- a/app/src/test/java/org/garret/perst/modes/SingleWriterModeTest.java
+++ b/app/src/test/java/org/garret/perst/modes/SingleWriterModeTest.java
@@ -17,7 +17,7 @@ public class SingleWriterModeTest {
 
     @Test
     public void singleWriterIncrements() throws Exception {
-        File dbFile = new File(getClass().getClassLoader().getResource("single_writer.dbs").toURI());
+        File dbFile = File.createTempFile("single_writer", ".dbs");
         dbFile.delete();
         Storage storage = StorageFactory.getInstance().createStorage();
         storage.open(dbFile.getPath());


### PR DESCRIPTION
## Summary
- pass `db` to `GraphNode` in `createNode` and `getOrCreateNode`
- ensure all `GraphNode` instantiations provide the storage instance
- use temporary files for continuous and single writer mode tests

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68aa41babb8883309c456785a7d987eb