### PR TITLE
refactor query request to use cypher string

### DIFF
--- a/server/src/main/biz/digitalindustry/db/server/controller/QueryController.java
+++ b/server/src/main/biz/digitalindustry/db/server/controller/QueryController.java
@@ -5,8 +5,6 @@ import model.QueryRequest;
 import model.QueryResponse;
 import io.micronaut.http.annotation.*;
 
-import java.util.*;
-
 @Controller("/query")
 public class QueryController {
     private final QueryHandlerRegistry registry;
@@ -17,18 +15,14 @@ public class QueryController {
 
     @Post
     public QueryResponse handleQuery(@Body QueryRequest request) {
-        Map<String, String> queries = request.getQuery();
+        String query = request.getCypher();
 
-        if (queries == null || queries.isEmpty()) {
+        if (query == null || query.isEmpty()) {
             throw new IllegalArgumentException("Missing query payload");
         }
 
-        Map.Entry<String, String> entry = queries.entrySet().iterator().next();
-        String queryType = entry.getKey();
-        String query = entry.getValue();
-
-        return registry.getHandler(queryType)
+        return registry.getHandler("cypher")
                 .map(handler -> new QueryResponse(handler.handle(query)))
-                .orElseThrow(() -> new IllegalArgumentException("Unsupported query type: " + queryType));
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported query type: cypher"));
     }
 }

--- a/server/src/main/biz/digitalindustry/db/server/model/QueryRequest.java
+++ b/server/src/main/biz/digitalindustry/db/server/model/QueryRequest.java
@@ -1,15 +1,13 @@
 package biz.digitalindustry.db.server.model;
 
-import java.util.*;
-
 public class QueryRequest {
-    private Map<String, String> query;
+    private String cypher;
 
-    public Map<String, String> getQuery() {
-        return query;
+    public String getCypher() {
+        return cypher;
     }
 
-    public void setQuery(Map<String, String> query) {
-        this.query = query;
+    public void setCypher(String cypher) {
+        this.cypher = cypher;
     }
 }


### PR DESCRIPTION
## Summary
- accept plain cypher in QueryRequest instead of map
- simplify QueryController to read request.getCypher()

## Testing
- `./gradlew -PmicronautVersion=4.3.4 :server:test` *(fails: Could not find io.micronaut.jackson:micronaut-jackson-databind)*

------
https://chatgpt.com/codex/tasks/task_e_68aab03cd5088330b71e14b26a4e491f