### PR TITLE
Directly invoke cypher query handler in QueryController

### DIFF
--- a/server/src/main/biz/digitalindustry/db/server/controller/QueryController.java
+++ b/server/src/main/biz/digitalindustry/db/server/controller/QueryController.java
@@ -23,6 +23,6 @@ public class QueryController {
 
         return registry.getHandler("cypher")
                 .map(handler -> new QueryResponse(handler.handle(query)))
-                .orElseThrow(() -> new IllegalArgumentException("Unsupported query type: cypher"));
+                .orElseThrow();
     }
 }


### PR DESCRIPTION
## Summary
- Simplify `QueryController` by directly retrieving the `cypher` handler and returning its structured output

## Testing
- `./gradlew test` *(fails: Micronaut version not set)*

------
https://chatgpt.com/codex/tasks/task_e_68aab35fc2608330ad18c84484f916cc