### PR TITLE
feat: build structured query response

### DIFF
--- a/server/src/main/biz/digitalindustry/db/server/controller/QueryController.java
+++ b/server/src/main/biz/digitalindustry/db/server/controller/QueryController.java
@@ -3,6 +3,7 @@ package biz.digitalindustry.db.server.controller;
 import biz.digitalindustry.db.server.model.QueryRequest;
 import biz.digitalindustry.db.server.model.QueryResponse;
 import biz.digitalindustry.db.server.queryhandler.QueryHandlerRegistry;
+import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.*;
 
 @Controller("/query")
@@ -14,6 +15,7 @@ public class QueryController {
     }
 
     @Post
+    @Produces(MediaType.APPLICATION_JSON)
     public QueryResponse handleQuery(@Body QueryRequest request) {
         String query = request.getCypher();
 

--- a/server/src/main/biz/digitalindustry/db/server/model/Node.java
+++ b/server/src/main/biz/digitalindustry/db/server/model/Node.java
@@ -2,8 +2,10 @@ package biz.digitalindustry.db.server.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
 import java.util.Map;
 
+@Introspected
 public class Node {
     private String id;
     private Map<String, Object> properties;

--- a/server/src/main/biz/digitalindustry/db/server/model/QueryRequest.java
+++ b/server/src/main/biz/digitalindustry/db/server/model/QueryRequest.java
@@ -1,5 +1,8 @@
 package biz.digitalindustry.db.server.model;
 
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
 public class QueryRequest {
     private String cypher;
 

--- a/server/src/main/biz/digitalindustry/db/server/model/QueryResponse.java
+++ b/server/src/main/biz/digitalindustry/db/server/model/QueryResponse.java
@@ -2,8 +2,10 @@ package biz.digitalindustry.db.server.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
 import java.util.*;
 
+@Introspected
 public class QueryResponse {
     private List<Map<String, Node>> results;
 

--- a/server/src/main/biz/digitalindustry/db/server/queryhandler/CypherQueryHandler.java
+++ b/server/src/main/biz/digitalindustry/db/server/queryhandler/CypherQueryHandler.java
@@ -3,20 +3,49 @@ package biz.digitalindustry.db.server.queryhandler;
 import biz.digitalindustry.db.server.model.Node;
 import biz.digitalindustry.db.server.model.QueryResponse;
 import jakarta.inject.Singleton;
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Singleton
 public class CypherQueryHandler implements QueryHandler {
     @Override
     public QueryResponse handle(String query) {
-        // TODO: call your graph engine here
+        // Placeholder for executing the Cypher query against the graph engine
+        List<Map<String, Object>> rawResults = executeCypher(query);
+
+        // Map the raw results into structured Node instances
+        List<Map<String, Node>> mappedResults = new ArrayList<>();
+        for (Map<String, Object> row : rawResults) {
+            Map<String, Node> mappedRow = new HashMap<>();
+            for (Map.Entry<String, Object> entry : row.entrySet()) {
+                // TODO: replace this placeholder with real mapping logic
+                Map<String, Object> props = entry.getValue() instanceof Map
+                        ? (Map<String, Object>) entry.getValue()
+                        : Map.of("value", entry.getValue());
+
+                Node node = new Node(UUID.randomUUID().toString(), props);
+                mappedRow.put(entry.getKey(), node);
+            }
+            mappedResults.add(mappedRow);
+        }
+
+        return new QueryResponse(mappedResults);
+    }
+
+    /**
+     * Simulates execution of a Cypher query. Replace with real integration.
+     */
+    private List<Map<String, Object>> executeCypher(String query) {
         Map<String, Object> properties = new HashMap<>();
         properties.put("result", "Processed Cypher query: " + query);
 
-        Node node = new Node("1", properties);
-        Map<String, Node> result = new HashMap<>();
-        result.put("node", node);
+        Map<String, Object> row = new HashMap<>();
+        row.put("node", properties);
 
-        return new QueryResponse(List.of(result));
+        return List.of(row);
     }
 }


### PR DESCRIPTION
## Summary
- generate a structured `QueryResponse` from cypher handler results instead of returning raw JSON
- enable Micronaut JSON serialization by annotating request/response models and controller
- add placeholder mapping of raw cypher rows into `Node` objects

## Testing
- `./gradlew test` *(fails: Micronaut version not set)*

------
https://chatgpt.com/codex/tasks/task_e_68aab4bafa1483309b57dc292fa2a495