### PR TITLE
Add tests for query endpoint

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,5 @@
 # https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties
 
 org.gradle.configuration-cache=true
+micronautVersion=4.0.0
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -12,6 +12,7 @@ repositories {
 }
 
 micronaut {
+    version(micronautVersion)
     runtime("netty")
     testRuntime("junit5")
     processing {
@@ -21,26 +22,36 @@ micronaut {
 }
 
 dependencies {
-    implementation("io.micronaut:micronaut-http-server-netty")
-    implementation("io.micronaut:micronaut-runtime")
-    implementation("io.micronaut.jackson:micronaut-jackson-databind")
+    implementation("io.micronaut:micronaut-http-server-netty:${micronautVersion}")
+    implementation("io.micronaut:micronaut-runtime:${micronautVersion}")
+    implementation("io.micronaut:micronaut-jackson-databind:${micronautVersion}")
     implementation("jakarta.annotation:jakarta.annotation-api")
     implementation("jakarta.inject:jakarta.inject-api")
 
     // Optional: Logging
-    runtimeOnly("ch.qos.logback:logback-classic")
+    runtimeOnly("ch.qos.logback:logback-classic:1.4.14")
 
     // Optional: If using Micronaut validation
-    implementation("io.micronaut.validation:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation:${micronautVersion}")
 
     // Testing
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation("io.micronaut.test:micronaut-test-junit5:${micronautVersion}")
+    testImplementation("io.micronaut:micronaut-http-client:${micronautVersion}")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
 }
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ["src/main"]
+        }
+    }
 }
 
 application {

--- a/server/src/test/java/biz/digitalindustry/db/server/controller/QueryControllerTest.java
+++ b/server/src/test/java/biz/digitalindustry/db/server/controller/QueryControllerTest.java
@@ -1,0 +1,77 @@
+package biz.digitalindustry.db.server.controller;
+
+import biz.digitalindustry.db.server.model.Node;
+import biz.digitalindustry.db.server.model.QueryRequest;
+import biz.digitalindustry.db.server.model.QueryResponse;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@MicronautTest
+class QueryControllerTest {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void testPostCypherQueryReturnsStructuredResults() {
+        QueryRequest request = new QueryRequest();
+        request.setCypher("MATCH (n) RETURN n");
+
+        HttpRequest<QueryRequest> httpRequest = HttpRequest.POST("/query", request);
+        HttpResponse<QueryResponse> response = client.toBlocking().exchange(httpRequest, QueryResponse.class);
+
+        assertEquals(HttpStatus.OK, response.getStatus());
+        QueryResponse body = response.body();
+        assertNotNull(body);
+        assertNotNull(body.getResults());
+        assertFalse(body.getResults().isEmpty());
+
+        Map<String, Node> row = body.getResults().get(0);
+        assertTrue(row.containsKey("node"));
+
+        Node node = row.get("node");
+        assertNotNull(node.getId());
+        assertEquals("Processed Cypher query: MATCH (n) RETURN n", node.getProperties().get("result"));
+    }
+
+    @Test
+    void testMissingCypherFieldReturnsError() {
+        QueryRequest request = new QueryRequest(); // cypher remains null
+        HttpRequest<QueryRequest> httpRequest = HttpRequest.POST("/query", request);
+
+        HttpClientResponseException ex = assertThrows(HttpClientResponseException.class,
+                () -> client.toBlocking().exchange(httpRequest, QueryResponse.class));
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
+        String body = ex.getResponse().getBody(String.class).orElse("");
+        assertTrue(body.contains("Missing query payload"));
+    }
+
+    @Test
+    void testEmptyCypherReturnsError() {
+        QueryRequest request = new QueryRequest();
+        request.setCypher("");
+        HttpRequest<QueryRequest> httpRequest = HttpRequest.POST("/query", request);
+
+        HttpClientResponseException ex = assertThrows(HttpClientResponseException.class,
+                () -> client.toBlocking().exchange(httpRequest, QueryResponse.class));
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
+        String body = ex.getResponse().getBody(String.class).orElse("");
+        assertTrue(body.contains("Missing query payload"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Micronaut/JUnit tests for /query endpoint covering valid and invalid requests
- configure build with Micronaut version and test dependencies

## Testing
- `./gradlew :server:test`


------
https://chatgpt.com/codex/tasks/task_e_68aab5ba39d88330a010d9ed64bb5e36