### PR TITLE
Support arbitrary query types via map in QueryRequest

### DIFF
--- a/server/src/main/biz/digitalindustry/db/server/controller/QueryController.java
+++ b/server/src/main/biz/digitalindustry/db/server/controller/QueryController.java
@@ -17,13 +17,14 @@ public class QueryController {
     @Post
     @Produces(MediaType.APPLICATION_JSON)
     public QueryResponse handleQuery(@Body QueryRequest request) {
-        String query = request.getCypher();
+        String queryType = request.getQueryType();
+        String query = request.getQuery();
 
-        if (query == null || query.isEmpty()) {
+        if (queryType == null || query == null || query.isEmpty()) {
             throw new IllegalArgumentException("Missing query payload");
         }
 
-        return registry.getHandler("cypher")
+        return registry.getHandler(queryType)
                 .map(handler -> handler.handle(query))
                 .orElseThrow();
     }

--- a/server/src/main/biz/digitalindustry/db/server/model/QueryRequest.java
+++ b/server/src/main/biz/digitalindustry/db/server/model/QueryRequest.java
@@ -1,16 +1,31 @@
 package biz.digitalindustry.db.server.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import io.micronaut.core.annotation.Introspected;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @Introspected
 public class QueryRequest {
-    private String cypher;
+    private final Map<String, String> queries = new LinkedHashMap<>();
 
-    public String getCypher() {
-        return cypher;
+    @JsonAnySetter
+    public void addQuery(String key, String value) {
+        queries.put(key, value);
     }
 
-    public void setCypher(String cypher) {
-        this.cypher = cypher;
+    @JsonAnyGetter
+    public Map<String, String> getQueries() {
+        return queries;
+    }
+
+    public String getQueryType() {
+        return queries.keySet().stream().findFirst().orElse(null);
+    }
+
+    public String getQuery() {
+        return queries.values().stream().findFirst().orElse(null);
     }
 }

--- a/server/src/test/java/biz/digitalindustry/db/server/controller/QueryControllerTest.java
+++ b/server/src/test/java/biz/digitalindustry/db/server/controller/QueryControllerTest.java
@@ -28,9 +28,9 @@ class QueryControllerTest {
     @Test
     void testPostCypherQueryReturnsStructuredResults() {
         QueryRequest request = new QueryRequest();
-        request.setCypher("MATCH (n) RETURN n");
+        request.addQuery("cypher", "MATCH (n) RETURN n");
 
-        HttpRequest<QueryRequest> httpRequest = HttpRequest.POST("/query", request);
+        HttpRequest<Map<String, String>> httpRequest = HttpRequest.POST("/query", request.getQueries());
         HttpResponse<QueryResponse> response = client.toBlocking().exchange(httpRequest, QueryResponse.class);
 
         assertEquals(HttpStatus.OK, response.getStatus());
@@ -49,8 +49,8 @@ class QueryControllerTest {
 
     @Test
     void testMissingCypherFieldReturnsError() {
-        QueryRequest request = new QueryRequest(); // cypher remains null
-        HttpRequest<QueryRequest> httpRequest = HttpRequest.POST("/query", request);
+        Map<String, String> request = Collections.emptyMap();
+        HttpRequest<Map<String, String>> httpRequest = HttpRequest.POST("/query", request);
 
         HttpClientResponseException ex = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(httpRequest, QueryResponse.class));
@@ -62,9 +62,8 @@ class QueryControllerTest {
 
     @Test
     void testEmptyCypherReturnsError() {
-        QueryRequest request = new QueryRequest();
-        request.setCypher("");
-        HttpRequest<QueryRequest> httpRequest = HttpRequest.POST("/query", request);
+        Map<String, String> request = Collections.singletonMap("cypher", "");
+        HttpRequest<Map<String, String>> httpRequest = HttpRequest.POST("/query", request);
 
         HttpClientResponseException ex = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(httpRequest, QueryResponse.class));


### PR DESCRIPTION
## Summary
- Allow `QueryRequest` to accept arbitrary query-type keys with a map
- Resolve first query type/value pair through helper methods for controller use
- Update controller and tests to use new structure

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68aabb3152088330bb3f9819bcb751bd