### PR TITLE
Validate query payload and handle unsupported query types

### DIFF
--- a/server/src/main/biz/digitalindustry/db/server/controller/QueryController.java
+++ b/server/src/main/biz/digitalindustry/db/server/controller/QueryController.java
@@ -3,8 +3,10 @@ package biz.digitalindustry.db.server.controller;
 import biz.digitalindustry.db.server.model.QueryRequest;
 import biz.digitalindustry.db.server.model.QueryResponse;
 import biz.digitalindustry.db.server.queryhandler.QueryHandlerRegistry;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.*;
+import io.micronaut.http.exceptions.HttpStatusException;
 
 @Controller("/query")
 public class QueryController {
@@ -17,15 +19,19 @@ public class QueryController {
     @Post
     @Produces(MediaType.APPLICATION_JSON)
     public QueryResponse handleQuery(@Body QueryRequest request) {
-        String queryType = request.getQueryType();
-        String query = request.getQuery();
+        String queryType = request.queryType();
+        String query = request.query();
 
-        if (queryType == null || query == null || query.isEmpty()) {
-            throw new IllegalArgumentException("Missing query payload");
+        if (queryType == null || queryType.isBlank()) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "queryType must not be null or empty");
+        }
+        if (query == null || query.isBlank()) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "query must not be null or empty");
         }
 
         return registry.getHandler(queryType)
                 .map(handler -> handler.handle(query))
-                .orElseThrow();
+                .orElseThrow(() -> new HttpStatusException(HttpStatus.BAD_REQUEST,
+                        "Unsupported query type: " + queryType));
     }
 }

--- a/server/src/main/biz/digitalindustry/db/server/model/QueryRequest.java
+++ b/server/src/main/biz/digitalindustry/db/server/model/QueryRequest.java
@@ -1,31 +1,7 @@
 package biz.digitalindustry.db.server.model;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import io.micronaut.core.annotation.Introspected;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 @Introspected
-public class QueryRequest {
-    private final Map<String, String> queries = new LinkedHashMap<>();
-
-    @JsonAnySetter
-    public void addQuery(String key, String value) {
-        queries.put(key, value);
-    }
-
-    @JsonAnyGetter
-    public Map<String, String> getQueries() {
-        return queries;
-    }
-
-    public String getQueryType() {
-        return queries.keySet().stream().findFirst().orElse(null);
-    }
-
-    public String getQuery() {
-        return queries.values().stream().findFirst().orElse(null);
-    }
+public record QueryRequest(String queryType, String query) {
 }


### PR DESCRIPTION
## Summary
- Use explicit `queryType` and `query` fields in `QueryRequest`
- Validate request payload and return `400` for missing values
- Report unsupported query types with a `400` status

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68aabd3530008330a4444e428cd9c79e