### PR TITLE
Allow registering multiple query handlers

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,28 @@
+# Server Module
+
+## Query Handlers
+
+`QueryHandlerRegistry` routes incoming queries to a handler based on the `queryType`.
+Handlers implement the `QueryHandler` interface and are registered under a key that
+represents their query language.
+
+### Adding a new handler
+
+1. Implement `QueryHandler` for your query language:
+   ```java
+   public class SqlQueryHandler implements QueryHandler {
+       public QueryResponse handle(String query) {
+           // execute SQL query
+       }
+   }
+   ```
+2. Register the handler when constructing `QueryHandlerRegistry`:
+   ```java
+   Map<String, QueryHandler> handlers = Map.of(
+       "cypher", new CypherQueryHandler(),
+       "sql", new SqlQueryHandler()
+   );
+   QueryHandlerRegistry registry = new QueryHandlerRegistry(handlers);
+   ```
+   Additional handlers like Gremlin can be appended to the map using their
+   associated query type keys.

--- a/server/src/main/biz/digitalindustry/db/server/queryhandler/QueryHandlerRegistry.java
+++ b/server/src/main/biz/digitalindustry/db/server/queryhandler/QueryHandlerRegistry.java
@@ -1,5 +1,6 @@
 package biz.digitalindustry.db.server.queryhandler;
 
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.*;
 
@@ -7,9 +8,21 @@ import java.util.*;
 public class QueryHandlerRegistry {
     private final Map<String, QueryHandler> handlers = new HashMap<>();
 
+    /**
+     * Construct a registry from an arbitrary set of handlers mapped by query type.
+     *
+     * @param handlers map of query type to handler
+     */
+    public QueryHandlerRegistry(Map<String, QueryHandler> handlers) {
+        this.handlers.putAll(handlers);
+    }
+
+    /**
+     * Convenience constructor used by DI to register the default Cypher handler.
+     */
+    @Inject
     public QueryHandlerRegistry(CypherQueryHandler cypherHandler) {
-        handlers.put("cypher", cypherHandler);
-        // Future: handlers.put("sql", sqlHandler), etc.
+        this(Map.of("cypher", cypherHandler));
     }
 
     public Optional<QueryHandler> getHandler(String key) {

--- a/server/src/test/java/biz/digitalindustry/db/server/queryhandler/QueryHandlerRegistryTest.java
+++ b/server/src/test/java/biz/digitalindustry/db/server/queryhandler/QueryHandlerRegistryTest.java
@@ -1,0 +1,26 @@
+package biz.digitalindustry.db.server.queryhandler;
+
+import biz.digitalindustry.db.server.model.QueryResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueryHandlerRegistryTest {
+
+    @Test
+    void supportsMultipleHandlers() {
+        QueryHandler cypher = q -> new QueryResponse();
+        QueryHandler sql = q -> new QueryResponse();
+
+        QueryHandlerRegistry registry = new QueryHandlerRegistry(Map.of(
+                "cypher", cypher,
+                "sql", sql
+        ));
+
+        assertTrue(registry.getHandler("cypher").isPresent());
+        assertTrue(registry.getHandler("sql").isPresent());
+        assertTrue(registry.getHandler("gremlin").isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Add constructor to `QueryHandlerRegistry` that accepts a map of query type to handler
- Document how to register additional handlers such as SQL or Gremlin
- Test registry behavior with multiple handlers

## Testing
- `./gradlew :server:test`


------
https://chatgpt.com/codex/tasks/task_e_68aabe5f93d88330a5b282825b67d7f3