### PR TITLE
Add SQL handler and expand query controller tests

### DIFF
--- a/server/src/main/biz/digitalindustry/db/server/model/QueryRequest.java
+++ b/server/src/main/biz/digitalindustry/db/server/model/QueryRequest.java
@@ -1,7 +1,58 @@
 package biz.digitalindustry.db.server.model;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import io.micronaut.core.annotation.Introspected;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Represents a query request where the query type is encoded as the key
+ * of the single entry in the JSON body.
+ */
 @Introspected
-public record QueryRequest(String queryType, String query) {
+public class QueryRequest {
+    private final Map<String, String> queries = new LinkedHashMap<>();
+
+    public QueryRequest() {
+    }
+
+    /**
+     * Adds a query of the given type. Used for JSON deserialization and tests.
+     */
+    @JsonAnySetter
+    public void setQuery(String name, String query) {
+        if (name != null) {
+            queries.put(name, query);
+        }
+    }
+
+    /**
+     * Convenience factory for tests.
+     */
+    public static QueryRequest of(String type, String query) {
+        QueryRequest req = new QueryRequest();
+        req.setQuery(type, query);
+        return req;
+    }
+
+    /**
+     * Returns the first query type supplied or {@code null} if none.
+     */
+    public String queryType() {
+        return queries.keySet().stream().findFirst().orElse(null);
+    }
+
+    /**
+     * Returns the query string for the first query type or {@code null} if none.
+     */
+    public String query() {
+        String type = queryType();
+        return type == null ? null : queries.get(type);
+    }
+
+    public Map<String, String> getQueries() {
+        return queries;
+    }
 }
+

--- a/server/src/main/biz/digitalindustry/db/server/queryhandler/QueryHandlerRegistry.java
+++ b/server/src/main/biz/digitalindustry/db/server/queryhandler/QueryHandlerRegistry.java
@@ -18,11 +18,14 @@ public class QueryHandlerRegistry {
     }
 
     /**
-     * Convenience constructor used by DI to register the default Cypher handler.
+     * Convenience constructor used by DI to register the built-in handlers.
      */
     @Inject
-    public QueryHandlerRegistry(CypherQueryHandler cypherHandler) {
-        this(Map.of("cypher", cypherHandler));
+    public QueryHandlerRegistry(CypherQueryHandler cypherHandler, SqlQueryHandler sqlHandler) {
+        this(Map.of(
+                "cypher", cypherHandler,
+                "sql", sqlHandler
+        ));
     }
 
     public Optional<QueryHandler> getHandler(String key) {

--- a/server/src/main/biz/digitalindustry/db/server/queryhandler/SqlQueryHandler.java
+++ b/server/src/main/biz/digitalindustry/db/server/queryhandler/SqlQueryHandler.java
@@ -1,0 +1,23 @@
+package biz.digitalindustry.db.server.queryhandler;
+
+import biz.digitalindustry.db.server.model.Node;
+import biz.digitalindustry.db.server.model.QueryResponse;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Simple SQL query handler used for testing.
+ */
+@Singleton
+public class SqlQueryHandler implements QueryHandler {
+    @Override
+    public QueryResponse handle(String query) {
+        Node node = new Node(UUID.randomUUID().toString(),
+                Map.of("result", "Processed SQL query: " + query));
+        return new QueryResponse(List.of(Map.of("row", node)));
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend `QueryRequest` to map query type to its query text and add factory helper
- register new `SqlQueryHandler` and wire it into `QueryHandlerRegistry`
- expand controller tests for SQL queries, unsupported types, and new request API

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68aabfaa7280833096aef4fd0109957f