### PR TITLE
Refactor DTOs to records and generify collections

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/impl/AltPersistentSet.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/AltPersistentSet.java
@@ -19,7 +19,7 @@ class AltPersistentSet<T> extends AltBtree<T> implements IPersistentSet<T> {
 
     public boolean contains(Object o) {
         Key key = new Key(o);
-        Iterator i = iterator(key, key, ASCENT_ORDER);
+        Iterator<T> i = iterator(key, key, ASCENT_ORDER);
         return i.hasNext();
     }
     
@@ -43,7 +43,7 @@ class AltPersistentSet<T> extends AltBtree<T> implements IPersistentSet<T> {
         if (!(o instanceof Set)) {
             return false;
         }
-        Collection c = (Collection) o;
+        Collection<?> c = (Collection<?>) o;
         if (c.size() != size()) {
             return false;
         }
@@ -52,7 +52,7 @@ class AltPersistentSet<T> extends AltBtree<T> implements IPersistentSet<T> {
 
     public int hashCode() {
         int h = 0;
-        Iterator i = iterator();
+        Iterator<T> i = iterator();
         while (i.hasNext()) {
             h += getStorage().getOid(i.next());
         }

--- a/perst-core/src/main/java/org/garret/perst/impl/PersistentSet.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/PersistentSet.java
@@ -65,7 +65,7 @@ class PersistentSet<T> extends Btree<T> implements IPersistentSet<T>
 
     public boolean contains(Object o) {
         Key key = new Key(o);
-        Iterator i = iterator(key, key, ASCENT_ORDER);
+        Iterator<T> i = iterator(key, key, ASCENT_ORDER);
         return i.hasNext();
     }
     
@@ -89,7 +89,7 @@ class PersistentSet<T> extends Btree<T> implements IPersistentSet<T>
         if (!(o instanceof Set)) {
             return false;
         }
-        Collection c = (Collection) o;
+        Collection<?> c = (Collection<?>) o;
         if (c.size() != size()) {
             return false;
         }
@@ -98,7 +98,7 @@ class PersistentSet<T> extends Btree<T> implements IPersistentSet<T>
 
     public int hashCode() {
         int h = 0;
-        Iterator i = iterator();
+        Iterator<T> i = iterator();
         while (i.hasNext()) {
             h += getStorage().getOid(i.next());
         }

--- a/perst-core/src/main/java/org/garret/perst/impl/ScalableSet.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/ScalableSet.java
@@ -120,7 +120,7 @@ class ScalableSet<T> extends PersistentCollection<T> implements IPersistentSet<T
         if (!(o instanceof Set)) {
             return false;
         }
-        Collection c = (Collection) o;
+        Collection<?> c = (Collection<?>) o;
         if (c.size() != size()) {
             return false;
         }

--- a/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
@@ -4548,7 +4548,7 @@ public class StorageImpl implements Storage {
             } else if (obj instanceof Collection && (!serializeSystemCollections || t.getName().startsWith("java.util."))) {
                 ClassDescriptor valueDesc = getClassDescriptor(obj.getClass());
                 offs = buf.packI4(offs, -ClassDescriptor.tpValueTypeBias - valueDesc.getOid());
-                Collection c = (Collection)obj;
+                Collection<?> c = (Collection<?>)obj;
                 offs = buf.packI4(offs, c.size());
                 for (Object elem : c) {
                     offs = swizzle(buf, offs, elem);
@@ -4556,10 +4556,10 @@ public class StorageImpl implements Storage {
             } else if (obj instanceof Map && (!serializeSystemCollections || t.getName().startsWith("java.util."))) {
                 ClassDescriptor valueDesc = getClassDescriptor(obj.getClass());
                 offs = buf.packI4(offs, -ClassDescriptor.tpValueTypeBias - valueDesc.getOid());
-                Map map = (Map)obj;
+                Map<?,?> map = (Map<?,?>)obj;
                 offs = buf.packI4(offs, map.size());
                 for (Object entry : map.entrySet()) {
-                    Map.Entry e = (Map.Entry)entry;
+                    Map.Entry<?,?> e = (Map.Entry<?,?>)entry;
                     offs = swizzle(buf, offs, e.getKey());
                     offs = swizzle(buf, offs, e.getValue());
                 }

--- a/perst-index-graph/src/main/java/biz/digitalindustry/db/graph/NodeQuery.java
+++ b/perst-index-graph/src/main/java/biz/digitalindustry/db/graph/NodeQuery.java
@@ -17,6 +17,6 @@ public class NodeQuery {
     }
 
     public List<GraphNode> collect() {
-        return nodes;
+        return List.copyOf(nodes);
     }
 }

--- a/perst-server/src/main/java/biz/digitalindustry/db/server/model/Node.java
+++ b/perst-server/src/main/java/biz/digitalindustry/db/server/model/Node.java
@@ -6,25 +6,15 @@ import io.micronaut.core.annotation.Introspected;
 import java.util.Map;
 
 @Introspected
-public class Node {
-    private String id;
-    private Map<String, Object> properties;
-
+public record Node(String id, Map<String, Object> properties) {
     public Node() {
+        this(null, Map.of());
     }
 
     @JsonCreator
     public Node(@JsonProperty("id") String id,
                 @JsonProperty("properties") Map<String, Object> properties) {
         this.id = id;
-        this.properties = properties;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public Map<String, Object> getProperties() {
-        return properties;
+        this.properties = properties == null ? Map.of() : Map.copyOf(properties);
     }
 }

--- a/perst-server/src/main/java/biz/digitalindustry/db/server/model/QueryResponse.java
+++ b/perst-server/src/main/java/biz/digitalindustry/db/server/model/QueryResponse.java
@@ -3,22 +3,21 @@ package biz.digitalindustry.db.server.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Introspected;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Introspected
-public class QueryResponse {
-    private List<Map<String, Node>> results;
-
+public record QueryResponse(List<Map<String, Node>> results) {
     public QueryResponse() {
-        this.results = new ArrayList<>();
+        this(List.of());
     }
 
     @JsonCreator
     public QueryResponse(@JsonProperty("results") List<Map<String, Node>> results) {
-        this.results = results;
-    }
-
-    public List<Map<String, Node>> getResults() {
-        return results;
+        this.results = results == null ? List.of() :
+                List.copyOf(results.stream()
+                        .map(Map::copyOf)
+                        .collect(Collectors.toList()));
     }
 }

--- a/perst-server/src/test/java/biz/digitalindustry/db/server/controller/QueryControllerTest.java
+++ b/perst-server/src/test/java/biz/digitalindustry/db/server/controller/QueryControllerTest.java
@@ -34,15 +34,15 @@ class QueryControllerTest {
         assertEquals(HttpStatus.OK, response.getStatus());
         QueryResponse body = response.body();
         assertNotNull(body);
-        assertNotNull(body.getResults());
-        assertFalse(body.getResults().isEmpty());
+        assertNotNull(body.results());
+        assertFalse(body.results().isEmpty());
 
-        Map<String, Node> row = body.getResults().get(0);
+        Map<String, Node> row = body.results().get(0);
         assertTrue(row.containsKey("node"));
 
         Node node = row.get("node");
-        assertNotNull(node.getId());
-        assertEquals("Processed Cypher query: MATCH (n) RETURN n", node.getProperties().get("result"));
+        assertNotNull(node.id());
+        assertEquals("Processed Cypher query: MATCH (n) RETURN n", node.properties().get("result"));
     }
 
     @Test
@@ -55,12 +55,12 @@ class QueryControllerTest {
         assertEquals(HttpStatus.OK, response.getStatus());
         QueryResponse body = response.body();
         assertNotNull(body);
-        assertFalse(body.getResults().isEmpty());
+        assertFalse(body.results().isEmpty());
 
-        Map<String, Node> row = body.getResults().get(0);
+        Map<String, Node> row = body.results().get(0);
         Node node = row.get("row");
         assertNotNull(node);
-        assertEquals("Processed SQL query: SELECT * FROM Person", node.getProperties().get("result"));
+        assertEquals("Processed SQL query: SELECT * FROM Person", node.properties().get("result"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Use Java records for Node and QueryResponse DTOs with immutable fields
- Return unmodifiable node lists from NodeQuery
- Parameterize PersistentSet implementations and Storage serialization to avoid raw collections
- Update tests for new record accessors

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5e7244a48330818cff33053e8353