### PR TITLE
Refactor storage orchestration into dedicated services

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/impl/ObjectCache.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/ObjectCache.java
@@ -1,0 +1,57 @@
+package org.garret.perst.impl;
+
+import org.garret.perst.*;
+
+/**
+ * Simple wrapper around {@link OidHashTable} providing a dedicated
+ * component for object cache operations.  The cache implementation
+ * is supplied by Perst and all calls are delegated to it.
+ */
+public class ObjectCache {
+    private final OidHashTable cache;
+
+    public ObjectCache(OidHashTable cache) {
+        this.cache = cache;
+    }
+
+    public boolean remove(int oid) {
+        return cache.remove(oid);
+    }
+
+    public void put(int oid, Object obj) {
+        cache.put(oid, obj);
+    }
+
+    public Object get(int oid) {
+        return cache.get(oid);
+    }
+
+    public void flush() {
+        cache.flush();
+    }
+
+    public void invalidate() {
+        cache.invalidate();
+    }
+
+    public void reload() {
+        cache.reload();
+    }
+
+    public void clear() {
+        cache.clear();
+    }
+
+    public int size() {
+        return cache.size();
+    }
+
+    public void setDirty(Object obj) {
+        cache.setDirty(obj);
+    }
+
+    public void clearDirty(Object obj) {
+        cache.clearDirty(obj);
+    }
+}
+

--- a/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
@@ -992,7 +992,7 @@ public class StorageImpl implements Storage {
 
         modified = false;
 
-        objectCache = createObjectCache(cacheKind, pagePoolSize, objectCacheInitSize);
+        objectCache = new ObjectCache(createObjectCache(cacheKind, pagePoolSize, objectCacheInitSize));
 
         objMap = new ObjectMap(objectCacheInitSize);
 
@@ -2647,7 +2647,7 @@ public class StorageImpl implements Storage {
      * @return transaction context associated with current thread
      */
     public ThreadTransactionContext getTransactionContext() {
-        return (ThreadTransactionContext)transactionContext.get();
+        return transactionManager.getContext();
     }
 
     /**
@@ -2657,9 +2657,7 @@ public class StorageImpl implements Storage {
      * @return transaction context previously associated with this thread
      */
     public ThreadTransactionContext setTransactionContext(ThreadTransactionContext ctx) {
-        ThreadTransactionContext oldCtx = (ThreadTransactionContext)transactionContext.get();
-        transactionContext.set(ctx);
-        return oldCtx;
+        return transactionManager.setContext(ctx);
     }
 
     public void beginSerializableTransaction()
@@ -5470,15 +5468,11 @@ public class StorageImpl implements Storage {
     Object    transactionMonitor;
     PersistentResource transactionLock;
 
-    final ThreadLocal<ThreadTransactionContext> transactionContext = new ThreadLocal<ThreadTransactionContext>() {
-         protected synchronized ThreadTransactionContext initialValue() {
-             return new ThreadTransactionContext();
-         }
-    };
+    TransactionManager transactionManager = new TransactionManager();
     boolean useSerializableTransactions;
 
 
-    OidHashTable     objectCache;
+    ObjectCache     objectCache;
     HashMap<Class,ClassDescriptor> classDescMap;
     ClassDescriptor  descList;
 }

--- a/perst-core/src/main/java/org/garret/perst/impl/TransactionManager.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/TransactionManager.java
@@ -1,0 +1,28 @@
+package org.garret.perst.impl;
+
+/**
+ * Dedicated component responsible for keeping transaction state on a
+ * per-thread basis.  StorageImpl delegates transaction context related
+ * operations to this manager which makes it easier to test and evolve
+ * transaction handling independently from storage orchestration.
+ */
+public class TransactionManager {
+    private final ThreadLocal<ThreadTransactionContext> context =
+        new ThreadLocal<ThreadTransactionContext>() {
+            @Override
+            protected ThreadTransactionContext initialValue() {
+                return new ThreadTransactionContext();
+            }
+        };
+
+    public ThreadTransactionContext getContext() {
+        return context.get();
+    }
+
+    public ThreadTransactionContext setContext(ThreadTransactionContext ctx) {
+        ThreadTransactionContext old = context.get();
+        context.set(ctx);
+        return old;
+    }
+}
+


### PR DESCRIPTION
## Summary
- Introduce `ObjectCache` wrapper around `OidHashTable` for cache operations
- Add `TransactionManager` to manage per-thread transaction contexts
- Delegate transaction-context methods in `StorageImpl` to the new manager and use `ObjectCache` for caching

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68ab619bcb4c8330a388bbf6a3b89577