### PR TITLE
Replace manual locking with ReentrantReadWriteLock

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/PersistentResource.java
+++ b/perst-core/src/main/java/org/garret/perst/PersistentResource.java
@@ -1,149 +1,97 @@
 package org.garret.perst;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 /**
  * Base class for persistent capable objects supporting locking
  */
 
 public class PersistentResource extends Persistent implements IResource {
-    public synchronized void sharedLock() {
-        Thread currThread = Thread.currentThread();
-        try { 
-            while (true) { 
-                if (owner == currThread) { 
-                    nWriters += 1;
-                    break;
-                } else if (nWriters == 0) { 
-                    if (storage == null || storage.lockObject(this)) { 
-                        nReaders += 1;
-                    }
-                    break;
-                } else { 
-                    wait();
-                }
-            }
-        } catch (InterruptedException x) { 
-            throw new StorageError(StorageError.LOCK_FAILED);
-        }
-    }
-                    
-    public boolean sharedLock(long timeout) {
-        Thread currThread = Thread.currentThread();
-        long startTime = System.currentTimeMillis();
-        synchronized (this) { 
-            try { 
-                while (true) { 
-                    if (owner == currThread) { 
-                        nWriters += 1;
-                        return true;
-                    } else if (nWriters == 0) { 
-                        if (storage == null || storage.lockObject(this)) { 
-                            nReaders += 1;
-                        }
-                        return true;
-                    } else { 
-                        long currTime = System.currentTimeMillis();
-                        if (currTime < startTime) { 
-                            currTime = startTime;
-                        }
-                        if (startTime + timeout <= currTime) { 
-                            return false;
-                        }
-                        wait(startTime + timeout - currTime);
-                    }
-                }
-            } catch (InterruptedException x) { 
-                return false;
-            }
-        }
-    }
-                    
-    public synchronized void exclusiveLock() {
-        Thread currThread = Thread.currentThread();
-        try { 
-            while (true) { 
-                if (owner == currThread) { 
-                    nWriters += 1;
-                    break;
-                } else if (nReaders == 0 && nWriters == 0) { 
-                    nWriters = 1;
-                    owner = currThread;
-                    if (storage != null) { 
-                        storage.lockObject(this);
-                    }
-                    break;
-                } else { 
-                    wait();
-                }
-            }
-        } catch (InterruptedException x) { 
-            throw new StorageError(StorageError.LOCK_FAILED);
-        }
-    }
-                    
-    public boolean exclusiveLock(long timeout) {
-        Thread currThread = Thread.currentThread();
-        long startTime = System.currentTimeMillis();
-        synchronized (this) { 
-            try { 
-                while (true) { 
-                    if (owner == currThread) { 
-                        nWriters += 1;
-                        return true;
-                    } else if (nReaders == 0 && nWriters == 0) { 
-                        nWriters = 1;
-                        owner = currThread;
-                        if (storage != null) { 
-                            storage.lockObject(this);
-                        }
-                        return true;
-                    } else { 
-                        long currTime = System.currentTimeMillis();
-                        if (currTime < startTime) { 
-                            currTime = startTime;
-                        }
-                        if (startTime + timeout <= currTime) { 
-                            return false;
-                        }
-                        wait(startTime + timeout - currTime);
-                    }
-                }
-            } catch (InterruptedException x) { 
-                return false;
-            }
-        }
-    }
-                   
-    public synchronized void unlock() { 
-        if (nWriters != 0) { 
-            if (--nWriters == 0) { 
-                owner = null;
-                notifyAll();
-            }
-        } else if (nReaders != 0) { 
-            if (--nReaders == 0) { 
-                notifyAll();
+    public void sharedLock() {
+        if (lock.isWriteLockedByCurrentThread()) {
+            lock.writeLock().lock();
+        } else {
+            lock.readLock().lock();
+            if (storage != null && lock.getReadLockCount() == 1 && !lock.isWriteLocked()) {
+                storage.lockObject(this);
             }
         }
     }
 
-    public synchronized void reset() { 
-        if (nWriters > 0) { 
-            nWriters = 0;
-            nReaders = 0;
-            owner = null;
-        } else if (nReaders > 0) { 
-            nReaders -= 1;
+    public boolean sharedLock(long timeout) {
+        if (lock.isWriteLockedByCurrentThread()) {
+            lock.writeLock().lock();
+            return true;
         }
-        notifyAll();
+        try {
+            if (lock.readLock().tryLock(timeout, TimeUnit.MILLISECONDS)) {
+                if (storage != null && lock.getReadLockCount() == 1 && !lock.isWriteLocked()) {
+                    storage.lockObject(this);
+                }
+                return true;
+            }
+            return false;
+        } catch (InterruptedException x) {
+            return false;
+        }
+    }
+
+    public void exclusiveLock() {
+        lock.writeLock().lock();
+        if (storage != null && lock.getReadLockCount() == 0 && lock.getWriteHoldCount() == 1) {
+            storage.lockObject(this);
+        }
+    }
+
+    public boolean exclusiveLock(long timeout) {
+        if (lock.isWriteLockedByCurrentThread()) {
+            lock.writeLock().lock();
+            return true;
+        }
+        try {
+            if (lock.writeLock().tryLock(timeout, TimeUnit.MILLISECONDS)) {
+                if (storage != null && lock.getReadLockCount() == 0 && lock.getWriteHoldCount() == 1) {
+                    storage.lockObject(this);
+                }
+                return true;
+            }
+            return false;
+        } catch (InterruptedException x) {
+            return false;
+        }
+    }
+
+    public void unlock() {
+        if (lock.isWriteLockedByCurrentThread()) {
+            lock.writeLock().unlock();
+        } else {
+            lock.readLock().unlock();
+        }
+    }
+
+    public void reset() {
+        while (lock.isWriteLockedByCurrentThread()) {
+            lock.writeLock().unlock();
+        }
+        int n = lock.getReadHoldCount();
+        for (int i = 0; i < n; i++) {
+            lock.readLock().unlock();
+        }
     }
 
     public PersistentResource() {}
-    
-    public PersistentResource(Storage storage) { 
+
+    public PersistentResource(Storage storage) {
         super(storage);
     }
 
-    private transient Thread owner;
-    private transient int    nReaders;
-    private transient int    nWriters;
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        lock = new ReentrantReadWriteLock();
+    }
+
+    private transient ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 }


### PR DESCRIPTION
## Summary
- replace custom owner/nReaders/nWriters tracking with a ReentrantReadWriteLock
- reimplement shared/exclusive locking and unlock using read/write lock APIs
- reset locks and restore transient lock after deserialization

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68ab65d2abc08330ad88e8fc2538d44b