### PR TITLE
Refactor PersistentCollection to rely on AbstractCollection

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/PersistentCollection.java
+++ b/perst-core/src/main/java/org/garret/perst/PersistentCollection.java
@@ -1,286 +1,276 @@
 package org.garret.perst;
-import  org.garret.perst.*;
-import  org.garret.perst.impl.QueryImpl;
-import  java.util.*;
 
-public abstract class PersistentCollection<T> extends PersistentResource implements ITable<T>
-{
-    public IterableIterator<T> select(Class cls, String predicate) { 
+import org.garret.perst.impl.QueryImpl;
+import org.garret.perst.impl.StorageImpl;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.util.AbstractCollection;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Base class for persistent collections. This class delegates all
+ * standard {@link java.util.Collection} behaviour to
+ * {@link java.util.AbstractCollection} and implements only
+ * persistence-specific functionality.
+ */
+public abstract class PersistentCollection<T> extends AbstractCollection<T>
+        implements ITable<T>, IPersistent, IResource, ICloneable, Pinned {
+
+    /* =======================================
+     *  Persistent and resource state handling
+     * ======================================= */
+
+    transient Storage storage;
+    transient int     oid;
+    transient int     state;
+
+    static public final int RAW   = 1;
+    static public final int DIRTY = 2;
+    static public final int DELETED = 4;
+
+    private transient ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    // IResource implementation
+    public void sharedLock() {
+        if (lock.isWriteLockedByCurrentThread()) {
+            lock.writeLock().lock();
+        } else {
+            lock.readLock().lock();
+            if (storage != null && lock.getReadLockCount() == 1 && !lock.isWriteLocked()) {
+                storage.lockObject(this);
+            }
+        }
+    }
+
+    public boolean sharedLock(long timeout) {
+        if (lock.isWriteLockedByCurrentThread()) {
+            lock.writeLock().lock();
+            return true;
+        }
+        try {
+            if (lock.readLock().tryLock(timeout, TimeUnit.MILLISECONDS)) {
+                if (storage != null && lock.getReadLockCount() == 1 && !lock.isWriteLocked()) {
+                    storage.lockObject(this);
+                }
+                return true;
+            }
+            return false;
+        } catch (InterruptedException x) {
+            return false;
+        }
+    }
+
+    public void exclusiveLock() {
+        lock.writeLock().lock();
+        if (storage != null && lock.getReadLockCount() == 0 && lock.getWriteHoldCount() == 1) {
+            storage.lockObject(this);
+        }
+    }
+
+    public boolean exclusiveLock(long timeout) {
+        if (lock.isWriteLockedByCurrentThread()) {
+            lock.writeLock().lock();
+            return true;
+        }
+        try {
+            if (lock.writeLock().tryLock(timeout, TimeUnit.MILLISECONDS)) {
+                if (storage != null && lock.getReadLockCount() == 0 && lock.getWriteHoldCount() == 1) {
+                    storage.lockObject(this);
+                }
+                return true;
+            }
+            return false;
+        } catch (InterruptedException x) {
+            return false;
+        }
+    }
+
+    public void unlock() {
+        if (lock.isWriteLockedByCurrentThread()) {
+            lock.writeLock().unlock();
+        } else {
+            lock.readLock().unlock();
+        }
+    }
+
+    public void reset() {
+        while (lock.isWriteLockedByCurrentThread()) {
+            lock.writeLock().unlock();
+        }
+        int n = lock.getReadHoldCount();
+        for (int i = 0; i < n; i++) {
+            lock.readLock().unlock();
+        }
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        lock = new ReentrantReadWriteLock();
+    }
+
+    // IPersistent implementation
+    public synchronized void load() {
+        if (oid != 0 && (state & RAW) != 0) {
+            storage.checkReadLock(getOid());
+            storage.loadObject(this);
+        }
+    }
+
+    public synchronized void loadAndModify() {
+        load();
+        modify();
+    }
+
+    public final boolean isRaw() {
+        return (state & RAW) != 0;
+    }
+
+    public final boolean isModified() {
+        return (state & DIRTY) != 0;
+    }
+
+    public final boolean isDeleted() {
+        return (state & DELETED) != 0;
+    }
+
+    public final boolean isPersistent() {
+        return oid != 0;
+    }
+
+    public void makePersistent(Storage storage) {
+        if (oid == 0) {
+            storage.makePersistent(this);
+        }
+    }
+
+    public void store() {
+        if ((state & RAW) != 0) {
+            throw new StorageError(StorageError.ACCESS_TO_STUB);
+        }
+        if (storage != null) {
+            storage.storeObject(this);
+            state &= ~DIRTY;
+        }
+    }
+
+    public void modify() {
+        if ((state & DIRTY) == 0 && oid != 0) {
+            if ((state & RAW) != 0) {
+                throw new StorageError(StorageError.ACCESS_TO_STUB);
+            }
+            Assert.that((state & DELETED) == 0);
+            storage.modifyObject(this);
+            state |= DIRTY;
+        }
+    }
+
+    public final int getOid() {
+        return oid;
+    }
+
+    public void deallocate() {
+        if (oid != 0) {
+            storage.deallocateObject(this);
+        }
+    }
+
+    public boolean recursiveLoading() {
+        return true;
+    }
+
+    public final Storage getStorage() {
+        return storage;
+    }
+
+    public void invalidate() {
+        state &= ~DIRTY;
+        state |= RAW;
+    }
+
+    public void unassignOid() {
+        oid = 0;
+        state = DELETED;
+        storage = null;
+    }
+
+    public void assignOid(Storage storage, int oid, boolean raw) {
+        this.oid = oid;
+        this.storage = storage;
+        if (raw) {
+            state |= RAW;
+        } else {
+            state &= ~RAW;
+        }
+    }
+
+    protected void clearState() {
+        state = 0;
+        oid = 0;
+    }
+
+    public Object clone() throws CloneNotSupportedException {
+        @SuppressWarnings("unchecked")
+        PersistentCollection<T> p = (PersistentCollection<T>)super.clone();
+        p.oid = 0;
+        p.state = 0;
+        return p;
+    }
+
+    public void readExternal(ObjectInput s) throws IOException, ClassNotFoundException {
+        oid = s.readInt();
+    }
+
+    public void writeExternal(ObjectOutput s) throws IOException {
+        if (s instanceof StorageImpl.PersistentObjectOutputStream) {
+            makePersistent(((StorageImpl.PersistentObjectOutputStream)s).getStorage());
+        }
+        s.writeInt(oid);
+    }
+
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (oid == 0) {
+            return super.equals(o);
+        }
+        return o instanceof IPersistent && ((IPersistent)o).getOid() == oid;
+    }
+
+    public int hashCode() {
+        return oid;
+    }
+
+    public void onLoad() {}
+    public void onStore() {}
+
+    /* =========================
+     *  Collection functionality
+     * ========================= */
+
+    public IterableIterator<T> select(Class cls, String predicate) {
         Query<T> query = new QueryImpl<T>(getStorage());
         return query.select(cls, iterator(), predicate);
     }
 
-    /**
-     * Returns <tt>true</tt> if this collection contains all of the elements
-     * in the specified collection. <p>
-     *
-     * This implementation iterates over the specified collection, checking
-     * each element returned by the iterator in turn to see if it's
-     * contained in this collection.  If all elements are so contained
-     * <tt>true</tt> is returned, otherwise <tt>false</tt>.
-     *
-     * @param c collection to be checked for containment in this collection.
-     * @return <tt>true</tt> if this collection contains all of the elements
-     * 	       in the specified collection.
-     * @throws NullPointerException if the specified collection is null.
-     * 
-     * @see #contains(Object)
-     */
-    public boolean containsAll(Collection<?> c) {
-	Iterator<?> e = c.iterator();
-	while (e.hasNext())
-	    if(!contains(e.next()))
-		return false;
-	return true;
-    }
-
-    /**
-     * Adds all of the elements in the specified collection to this collection
-     * (optional operation).  The behavior of this operation is undefined if
-     * the specified collection is modified while the operation is in
-     * progress.  (This implies that the behavior of this call is undefined if
-     * the specified collection is this collection, and this collection is
-     * nonempty.) <p>
-     *
-     * This implementation iterates over the specified collection, and adds
-     * each object returned by the iterator to this collection, in turn.<p>
-     *
-     * Note that this implementation will throw an
-     * <tt>UnsupportedOperationException</tt> unless <tt>add</tt> is
-     * overridden (assuming the specified collection is non-empty).
-     *
-     * @param c collection whose elements are to be added to this collection.
-     * @return <tt>true</tt> if this collection changed as a result of the
-     *         call.
-     * @throws UnsupportedOperationException if this collection does not
-     *         support the <tt>addAll</tt> method.
-     * @throws NullPointerException if the specified collection is null.
-     * 
-     * @see #add(Object)
-     */
-    public boolean addAll(Collection<? extends T> c) {
-	boolean modified = false;
-	Iterator<? extends T> e = c.iterator();
-	while (e.hasNext()) {
-	    if (add(e.next()))
-		modified = true;
-	}
-	return modified;
-    }
-
-    /**
-     * Removes from this collection all of its elements that are contained in
-     * the specified collection (optional operation). <p>
-     *
-     * This implementation iterates over this collection, checking each
-     * element returned by the iterator in turn to see if it's contained
-     * in the specified collection.  If it's so contained, it's removed from
-     * this collection with the iterator's <tt>remove</tt> method.<p>
-     *
-     * Note that this implementation will throw an
-     * <tt>UnsupportedOperationException</tt> if the iterator returned by the
-     * <tt>iterator</tt> method does not implement the <tt>remove</tt> method
-     * and this collection contains one or more elements in common with the
-     * specified collection.
-     *
-     * @param c elements to be removed from this collection.
-     * @return <tt>true</tt> if this collection changed as a result of the
-     *         call.
-     * @throws UnsupportedOperationException if the <tt>removeAll</tt> method
-     * 	       is not supported by this collection.
-     * @throws NullPointerException if the specified collection is null.
-     *
-     * @see #remove(Object)
-     * @see #contains(Object)
-     */
-    public boolean removeAll(Collection<?> c) {
-        boolean modified = false;
-        Iterator<?> i = c.iterator();
-        while (i.hasNext()) {
-            modified |= remove(i.next());
-        }
-        return modified;
-    }
-
-    /**
-     * Retains only the elements in this collection that are contained in the
-     * specified collection (optional operation).  In other words, removes
-     * from this collection all of its elements that are not contained in the
-     * specified collection. <p>
-     *
-     * This implementation iterates over this collection, checking each
-     * element returned by the iterator in turn to see if it's contained
-     * in the specified collection.  If it's not so contained, it's removed
-     * from this collection with the iterator's <tt>remove</tt> method.<p>
-     *
-     * Note that this implementation will throw an
-     * <tt>UnsupportedOperationException</tt> if the iterator returned by the
-     * <tt>iterator</tt> method does not implement the <tt>remove</tt> method
-     * and this collection contains one or more elements not present in the
-     * specified collection.
-     *
-     * @param c elements to be retained in this collection.
-     * @return <tt>true</tt> if this collection changed as a result of the
-     *         call.
-     * @throws UnsupportedOperationException if the <tt>retainAll</tt> method
-     * 	       is not supported by this Collection.
-     * @throws NullPointerException if the specified collection is null.
-     *
-     * @see #remove(Object)
-     * @see #contains(Object)
-     */
-    public boolean retainAll(Collection<?> c) {
-        ArrayList<T> toBeRemoved = new ArrayList<T>();
-        Iterator<T> i = iterator();
-        while (i.hasNext()) {
-            T o = i.next();
-            if (!c.contains(o)) {
-                toBeRemoved.add(o);
-            }
-        }
-        int n = toBeRemoved.size();
-        for (int j = 0; j < n; j++) { 
-            remove(toBeRemoved.get(j));
-        }
-        return n != 0;         
-    }
-
-    /**
-     * Returns <tt>true</tt> if this collection contains the specified
-     * element.  More formally, returns <tt>true</tt> if and only if this
-     * collection contains at least one element <tt>e</tt> such that
-     * <tt>(o==null ? e==null : o.equals(e))</tt>.<p>
-     *
-     * This implementation iterates over the elements in the collection,
-     * checking each element in turn for equality with the specified element.
-     *
-     * @param o object to be checked for containment in this collection.
-     * @return <tt>true</tt> if this collection contains the specified element.
-     */
-    public boolean contains(Object o) {
-	Iterator<T> e = iterator();
-	if (o==null) {
-	    while (e.hasNext())
-		if (e.next()==null)
-		    return true;
-	} else {
-	    while (e.hasNext())
-		if (o.equals(e.next()))
-		    return true;
-	}
-	return false;
-    }
-
-    /**
-     * Removes a single instance of the specified element from this
-     * collection, if it is present (optional operation).  More formally,
-     * removes an element <tt>e</tt> such that <tt>(o==null ? e==null :
-     * o.equals(e))</tt>, if the collection contains one or more such
-     * elements.  Returns <tt>true</tt> if the collection contained the
-     * specified element (or equivalently, if the collection changed as a
-     * result of the call).<p>
-     *
-     * This implementation iterates over the collection looking for the
-     * specified element.  If it finds the element, it removes the element
-     * from the collection using the iterator's remove method.<p>
-     *
-     * Note that this implementation throws an
-     * <tt>UnsupportedOperationException</tt> if the iterator returned by this
-     * collection's iterator method does not implement the <tt>remove</tt>
-     * method and this collection contains the specified object.
-     *
-     * @param o element to be removed from this collection, if present.
-     * @return <tt>true</tt> if the collection contained the specified
-     *         element.
-     * @throws UnsupportedOperationException if the <tt>remove</tt> method is
-     * 		  not supported by this collection.
-     */
-    public boolean remove(Object o) {
-	Iterator<T> e = iterator();
-	if (o==null) {
-	    while (e.hasNext()) {
-		if (e.next()==null) {
-		    e.remove();
-		    return true;
-		}
-	    }
-	} else {
-	    while (e.hasNext()) {
-		if (o.equals(e.next())) {
-		    e.remove();
-		    return true;
-		}
-	    }
-	}
-	return false;
-    }
-
-    /**
-     * Ensures that this collection contains the specified element (optional
-     * operation).  Returns <tt>true</tt> if the collection changed as a
-     * result of the call.  (Returns <tt>false</tt> if this collection does
-     * not permit duplicates and already contains the specified element.)
-     * Collections that support this operation may place limitations on what
-     * elements may be added to the collection.  In particular, some
-     * collections will refuse to add <tt>null</tt> elements, and others will
-     * impose restrictions on the type of elements that may be added.
-     * Collection classes should clearly specify in their documentation any
-     * restrictions on what elements may be added.<p>
-     *
-     * This implementation always throws an
-     * <tt>UnsupportedOperationException</tt>.
-     *
-     * @param o element whose presence in this collection is to be ensured.
-     * @return <tt>true</tt> if the collection changed as a result of the call.
-     * 
-     * @throws UnsupportedOperationException if the <tt>add</tt> method is not
-     *		  supported by this collection.
-     * 
-     * @throws NullPointerException if this collection does not permit
-     * 		  <tt>null</tt> elements, and the specified element is
-     * 		  <tt>null</tt>.
-     * 
-     * @throws ClassCastException if the class of the specified element
-     * 		  prevents it from being added to this collection.
-     * 
-     * @throws IllegalArgumentException if some aspect of this element
-     *            prevents it from being added to this collection.
-     */
-    public boolean add(T o) {
-	throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Returns <tt>true</tt> if this collection contains no elements.<p>
-     *
-     * This implementation returns <tt>size() == 0</tt>.
-     *
-     * @return <tt>true</tt> if this collection contains no elements.
-     */
-    public boolean isEmpty() {
-	return size() == 0;
-    }
-
     public void deallocateMembers() {
         Iterator<T> i = iterator();
-        while (i.hasNext()) { 
+        while (i.hasNext()) {
             storage.deallocate(i.next());
         }
         clear();
     }
 
-
-
-    /**
-     * Default constructor
-     */
+    // Constructors
     public PersistentCollection() {}
 
-    /**
-     * Constructor of the collection associated with the specified storage
-     * @param storage storage associated with the collection
-     */
-    public PersistentCollection(Storage storage) { 
-        super(storage);
+    public PersistentCollection(Storage storage) {
+        this.storage = storage;
     }
-}    
+}
+


### PR DESCRIPTION
## Summary
- redesign PersistentCollection to extend AbstractCollection and implement persistence/resource interfaces
- keep only persistence-specific behaviors like select and deallocateMembers

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68ab68d1ae148330afb54dd50e6bb514