### PR TITLE
feat: add AutoCloseable transaction API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,20 @@ storage.open("data.dbs");
 storage.setWriterThread(Thread.currentThread());
 
 Thread reader = new Thread(() -> {
-    storage.beginThreadTransaction(Storage.READ_ONLY_TRANSACTION);
-    try {
-        MyRoot root = storage.getRoot();
-        System.out.println(root.value);
-    } finally {
-        storage.endThreadTransaction();
-    }
+try (Transaction tx = storage.beginTransaction(TransactionMode.READ_ONLY)) {
+    MyRoot root = storage.getRoot();
+    System.out.println(root.value);
+}
 });
 
 reader.start();
 
 // All updates must run on the writer thread
-storage.beginThreadTransaction(Storage.EXCLUSIVE_TRANSACTION);
-try {
+try (Transaction tx = storage.beginTransaction(TransactionMode.EXCLUSIVE)) {
     MyRoot root = storage.getRoot();
     root.value++;
     storage.modify(root);
     storage.commit();
-} finally {
-    storage.endThreadTransaction();
 }
 
 reader.join();

--- a/perst-core/src/main/java/org/garret/perst/Storage.java
+++ b/perst-core/src/main/java/org/garret/perst/Storage.java
@@ -645,8 +645,9 @@ public interface Storage extends StorageLifecycle, TransactionManager, BackupSer
      * <TD>Supports access to the same database file by multiple applications.
      * In this case Perst will use file locking to synchronize access to the database file.
      * An application MUST wrap any access to the database with  beginThreadThreansaction/endThreadTransaction 
-     * methods. For read only access use READ_ONLY_TRANSACTION mode and if transaction may modify database then
-     * READ_WRITE_TRANSACTION mode should be used.
+     * methods. For read only access use {@link TransactionMode#READ_ONLY} mode and if
+     * transaction may modify database then {@link TransactionMode#READ_WRITE} mode should
+     * be used.
      * </TD></TR>
      * <TR><TD><code>perst.reload.objects.on.rollback</code></TD><TD>Boolean</TD><TD>false</TD>
      * <TD>By default, Perst doesn't reload modified objects after a transaction

--- a/perst-core/src/main/java/org/garret/perst/Transaction.java
+++ b/perst-core/src/main/java/org/garret/perst/Transaction.java
@@ -1,0 +1,32 @@
+package org.garret.perst;
+
+/**
+ * Transaction handle that begins a transaction upon creation and commits or
+ * rolls it back when closed. Commit is performed by default; calling
+ * {@link #rollback()} will cause the transaction to roll back instead.
+ */
+public class Transaction implements AutoCloseable {
+    private final TransactionManager storage;
+    private boolean rollback;
+
+    Transaction(TransactionManager storage, TransactionMode mode) {
+        this.storage = storage;
+        storage.beginThreadTransaction(mode);
+    }
+
+    /**
+     * Mark this transaction to be rolled back when it is closed.
+     */
+    public void rollback() {
+        this.rollback = true;
+    }
+
+    @Override
+    public void close() {
+        if (rollback) {
+            storage.rollbackThreadTransaction();
+        } else {
+            storage.endThreadTransaction();
+        }
+    }
+}

--- a/perst-core/src/main/java/org/garret/perst/TransactionManager.java
+++ b/perst-core/src/main/java/org/garret/perst/TransactionManager.java
@@ -4,19 +4,6 @@ package org.garret.perst;
  * Service interface for transaction management operations.
  */
 public interface TransactionManager {
-    /** Exclusive per-thread transaction: each thread access database in exclusive mode */
-    int EXCLUSIVE_TRANSACTION = 0;
-    /** Alias for EXCLUSIVE_TRANSACTION. In case of multiclient access,
-     * any transaction modifying database should be exclusive. */
-    int READ_WRITE_TRANSACTION = EXCLUSIVE_TRANSACTION;
-    /** Cooperative mode; all threads share the same transaction. */
-    int COOPERATIVE_TRANSACTION = 1;
-    /** Alias for COOPERATIVE_TRANSACTION. Only read-only transactions can be executed in parallel. */
-    int READ_ONLY_TRANSACTION = COOPERATIVE_TRANSACTION;
-    /** Serializable per-thread transaction. */
-    int SERIALIZABLE_TRANSACTION = 2;
-    /** Read only transaction which can be started at replication slave node. */
-    int REPLICATION_SLAVE_TRANSACTION = 3;
 
     /** Commit changes done by the last transaction. */
     void commit();
@@ -25,7 +12,18 @@ public interface TransactionManager {
     void rollback();
 
     /** Begin per-thread transaction. */
-    void beginThreadTransaction(int mode);
+    void beginThreadTransaction(TransactionMode mode);
+
+    /**
+     * Convenience method returning {@link Transaction} object allowing
+     * the use of try-with-resources statement for transactions.
+     *
+     * @param mode transaction mode
+     * @return transaction handle
+     */
+    default Transaction beginTransaction(TransactionMode mode) {
+        return new Transaction(this, mode);
+    }
 
     /** End per-thread transaction started by beginThreadTransaction method. */
     void endThreadTransaction();

--- a/perst-core/src/main/java/org/garret/perst/TransactionMode.java
+++ b/perst-core/src/main/java/org/garret/perst/TransactionMode.java
@@ -1,0 +1,19 @@
+package org.garret.perst;
+
+/**
+ * Transaction modes for thread-bound transactions.
+ */
+public enum TransactionMode {
+    /** Exclusive per-thread transaction: each thread accesses database in exclusive mode. */
+    EXCLUSIVE,
+    /** Alias for EXCLUSIVE. Any transaction modifying database should be exclusive. */
+    READ_WRITE,
+    /** Cooperative mode; all threads share the same transaction. */
+    COOPERATIVE,
+    /** Alias for COOPERATIVE. Only read-only transactions can be executed in parallel. */
+    READ_ONLY,
+    /** Serializable per-thread transaction. */
+    SERIALIZABLE,
+    /** Read only transaction which can be started at replication slave node. */
+    REPLICATION_SLAVE
+}

--- a/perst-core/src/main/java/org/garret/perst/impl/ReplicationSlaveStorageImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/ReplicationSlaveStorageImpl.java
@@ -55,7 +55,7 @@ public abstract class ReplicationSlaveStorageImpl extends StorageImpl implements
         waitSynchronizationCompletion();
         waitInitializationCompletion(); 
         opened = true;
-        beginThreadTransaction(REPLICATION_SLAVE_TRANSACTION);
+        beginThreadTransaction(TransactionMode.REPLICATION_SLAVE);
         reloadScheme();
         endThreadTransaction();
     }
@@ -69,9 +69,9 @@ public abstract class ReplicationSlaveStorageImpl extends StorageImpl implements
         return socket != null;
     }
     
-    public void beginThreadTransaction(int mode)
+    public void beginThreadTransaction(TransactionMode mode)
     {
-        if (mode != REPLICATION_SLAVE_TRANSACTION) {
+        if (mode != TransactionMode.REPLICATION_SLAVE) {
             throw new IllegalArgumentException("Illegal transaction mode");
         }
         lock.sharedLock();

--- a/tst/Benchmark.java
+++ b/tst/Benchmark.java
@@ -41,8 +41,8 @@ public class Benchmark {
             db.open("benchmark.dbs", pagePoolSize);
         }
 
-        if (serializableTransaction) { 
-            db.beginThreadTransaction(Storage.SERIALIZABLE_TRANSACTION);
+        if (serializableTransaction) {
+            db.beginThreadTransaction(TransactionMode.SERIALIZABLE);
         }
             
         Indices root = (Indices)db.getRoot();
@@ -60,10 +60,10 @@ public class Benchmark {
             intIndex.put(new Key(rec.intKey), rec);                
         }
         
-        if (serializableTransaction) { 
+        if (serializableTransaction) {
             db.endThreadTransaction();
-            db.beginThreadTransaction(Storage.SERIALIZABLE_TRANSACTION);
-        } else { 
+            db.beginThreadTransaction(TransactionMode.SERIALIZABLE);
+        } else {
             db.commit();
         }
         //db.gc();

--- a/tst/Guess.java
+++ b/tst/Guess.java
@@ -80,21 +80,15 @@ public class Guess extends Persistent {
 
         db.open("guess.dbs", 4*1024*1024, "GUESS");
         
-        while (askQuestion("Think of an animal. Ready (y/n) ? ")) { 
-            if (multiclient) { 
-                db.beginThreadTransaction(Storage.READ_WRITE_TRANSACTION);
-            }
-            Guess root = (Guess)db.getRoot();
-            if (root == null) { 
-                root = whoIsIt(null);
-                db.setRoot(root);
-            } else { 
-                root.dialog();
-            }
-            if (multiclient) { 
-                db.endThreadTransaction();
-            } else { 
-                db.commit();
+        while (askQuestion("Think of an animal. Ready (y/n) ? ")) {
+            try (Transaction tx = db.beginTransaction(TransactionMode.READ_WRITE)) {
+                Guess root = (Guess)db.getRoot();
+                if (root == null) {
+                    root = whoIsIt(null);
+                    db.setRoot(root);
+                } else {
+                    root.dialog();
+                }
             }
         }
         

--- a/tst/TestReplic.java
+++ b/tst/TestReplic.java
@@ -83,24 +83,24 @@ public class TestReplic {
             db.open("slave.dbs", pagePoolSize);         
             long total = 0;
             int n = 0;
-            while (db.isConnected()) { 
+            while (db.isConnected()) {
                 db.waitForModification();
-                db.beginThreadTransaction(Storage.REPLICATION_SLAVE_TRANSACTION);
-                FieldIndex<Record> root = (FieldIndex<Record>)db.getRoot();
-                if (root != null && root.size() == nRecords) {
-                    long start = System.currentTimeMillis();
-                    Iterator<Record> iterator = root.iterator();
-                    int prevKey = iterator.next().key;
-                    for (i = 1; iterator.hasNext(); i++) { 
-                        int key = iterator.next().key;
-                        Assert.that(key == prevKey+1);
-                        prevKey = key;
+                try (Transaction tx = db.beginTransaction(TransactionMode.REPLICATION_SLAVE)) {
+                    FieldIndex<Record> root = (FieldIndex<Record>)db.getRoot();
+                    if (root != null && root.size() == nRecords) {
+                        long start = System.currentTimeMillis();
+                        Iterator<Record> iterator = root.iterator();
+                        int prevKey = iterator.next().key;
+                        for (i = 1; iterator.hasNext(); i++) {
+                            int key = iterator.next().key;
+                            Assert.that(key == prevKey+1);
+                            prevKey = key;
+                        }
+                        Assert.that(i == nRecords);
+                        n += 1;
+                        total += (System.currentTimeMillis() - start);
                     }
-                    Assert.that(i == nRecords);
-                    n += 1;
-                    total += (System.currentTimeMillis() - start);
                 }
-                db.endThreadTransaction();
             }
             db.close();
             System.out.println("Elapsed time for " + n + " iterations: " + total + " milliseconds");

--- a/tst/TestServer.java
+++ b/tst/TestServer.java
@@ -35,13 +35,13 @@ public class TestServer {
             String tid = "Thread" + id + ":";
             FieldIndex index = root.indices[id % nIndices];
 
-            for (i = 0; i < nRecords; i++) { 
-                db.beginThreadTransaction(Storage.SERIALIZABLE_TRANSACTION);
-                index.exclusiveLock();
-                Record rec = new Record();
-                rec.key = tid + toStr(i);
-                index.put(rec);
-                db.endThreadTransaction();
+            for (i = 0; i < nRecords; i++) {
+                try (Transaction tx = db.beginTransaction(TransactionMode.SERIALIZABLE)) {
+                    index.exclusiveLock();
+                    Record rec = new Record();
+                    rec.key = tid + toStr(i);
+                    index.put(rec);
+                }
             }
 
             index.sharedLock();
@@ -61,12 +61,12 @@ public class TestServer {
                 index.unlock();
             }
 
-            for (i = 0; i < nRecords; i++) { 
-                db.beginThreadTransaction(Storage.SERIALIZABLE_TRANSACTION);
-                index.exclusiveLock();
-                Record rec = (Record)index.remove(new Key(tid + toStr(i)));
-                rec.deallocate();
-                db.endThreadTransaction();
+            for (i = 0; i < nRecords; i++) {
+                try (Transaction tx = db.beginTransaction(TransactionMode.SERIALIZABLE)) {
+                    index.exclusiveLock();
+                    Record rec = (Record)index.remove(new Key(tid + toStr(i)));
+                    rec.deallocate();
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `TransactionMode` enum for transaction types
- provide `Transaction` AutoCloseable helper and default `beginTransaction`
- refactor storage internals and samples to use new transaction API

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6eaf1c88833098760540195d28ec