### PR TITLE
Use generics for map creation and iterator parameters

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/Bitmap.java
+++ b/perst-core/src/main/java/org/garret/perst/Bitmap.java
@@ -152,7 +152,7 @@ public class Bitmap implements Iterable
      * @param sto storage of persistent object selected by this bitmap
      * @param i iterator through persistent object which is used to initialize bitmap
      */
-    public Bitmap(Storage sto, Iterator i) 
+    public Bitmap(Storage sto, Iterator<?> i)
     { 
         storage = sto;
         n_bits = sto.getMaxOid();

--- a/perst-core/src/main/java/org/garret/perst/IPersistentMap.java
+++ b/perst-core/src/main/java/org/garret/perst/IPersistentMap.java
@@ -5,7 +5,7 @@ import java.util.*;
 /**
  * Interface of persistent map
  */
-public interface IPersistentMap<K extends Comparable,V> extends SortedMap<K,V>, IPersistent, IResource
+public interface IPersistentMap<K extends Comparable<? super K>,V> extends SortedMap<K,V>, IPersistent, IResource
 {
     /**
      * Get entry for the specified key. 

--- a/perst-core/src/main/java/org/garret/perst/Storage.java
+++ b/perst-core/src/main/java/org/garret/perst/Storage.java
@@ -66,7 +66,7 @@ public interface Storage extends StorageLifecycle, TransactionManager, BackupSer
      * @param iterator persistent objects iterator which is used to construct bitmap
      * @return bitmap for this selection
      */
-    public Bitmap createBitmap(Iterator iterator);
+    public Bitmap createBitmap(Iterator<?> iterator);
 
     /**
      * Create scalable persistent map.
@@ -75,7 +75,7 @@ public interface Storage extends StorageLifecycle, TransactionManager, BackupSer
      * @param keyType map key type
      * @return scalable map implementation
      */
-    public <K extends Comparable, V> IPersistentMap<K,V> createMap(Class keyType);
+    public <K extends Comparable<? super K>, V> IPersistentMap<K,V> createMap(Class<K> keyType);
 
     /**
      * Create scalable persistent map.
@@ -85,7 +85,7 @@ public interface Storage extends StorageLifecycle, TransactionManager, BackupSer
      * @param initialSize initial allocated size of the list
      * @return scalable map implementation
      */
-    public <K extends Comparable, V> IPersistentMap<K,V> createMap(Class keyType, int initialSize);
+    public <K extends Comparable<? super K>, V> IPersistentMap<K,V> createMap(Class<K> keyType, int initialSize);
 
     /**
      * Create new peristent set. Implementation of this set is based on B-Tree so it can efficiently

--- a/perst-core/src/main/java/org/garret/perst/impl/FullTextIndexImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/FullTextIndexImpl.java
@@ -46,18 +46,19 @@ public class FullTextIndexImpl extends PersistentResource implements FullTextInd
             throw new UnsupportedOperationException();
         }
 
-        KeywordIterator(Iterator iterator) {
+        KeywordIterator(Iterator<Map.Entry<?, ?>> iterator) {
             this.iterator = iterator;
         }
 
-        Iterator iterator;
+        Iterator<Map.Entry<?, ?>> iterator;
     }
 
 
+    @SuppressWarnings("unchecked")
     public Iterator<Keyword> getKeywords(String prefix) {
-        return new KeywordIterator(inverseIndex.entryIterator(new Key(prefix), 
-                                                              new Key(prefix + Character.MAX_VALUE, false), 
-                                                              Index.ASCENT_ORDER));
+        return new KeywordIterator((Iterator<Map.Entry<?, ?>>)inverseIndex.entryIterator(new Key(prefix),
+                                                                                      new Key(prefix + Character.MAX_VALUE, false),
+                                                                                      Index.ASCENT_ORDER));
     }
     
     static class DocumentOccurrences extends Persistent {

--- a/perst-core/src/main/java/org/garret/perst/impl/PersistentMapImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/PersistentMapImpl.java
@@ -2,7 +2,7 @@ package org.garret.perst.impl;
 import  org.garret.perst.*;
 import  java.util.*;
 
-class PersistentMapImpl<K extends Comparable, V> extends PersistentResource implements IPersistentMap<K, V>
+class PersistentMapImpl<K extends Comparable<? super K>, V> extends PersistentResource implements IPersistentMap<K, V>
 {
     IPersistent index;
     Object      keys;
@@ -15,14 +15,14 @@ class PersistentMapImpl<K extends Comparable, V> extends PersistentResource impl
 
     static final int BTREE_TRESHOLD = 128;
 
-    PersistentMapImpl(Storage storage, Class keyType, int initialSize) { 
+    PersistentMapImpl(Storage storage, Class<K> keyType, int initialSize) {
         super(storage);
         type = getTypeCode(keyType);
         keys = new Comparable[initialSize];
         values = storage.<V>createLink(initialSize);
     }
 
-   static class PersistentMapEntry<K extends Comparable,V> extends Persistent implements Entry<K,V> { 
+   static class PersistentMapEntry<K extends Comparable<? super K>,V> extends Persistent implements Entry<K,V> {
         K key;
         V value;
 
@@ -48,13 +48,14 @@ class PersistentMapImpl<K extends Comparable, V> extends PersistentResource impl
         PersistentMapEntry() {}
     }
 
-    static class PersistentMapComparator<K extends Comparable, V> extends PersistentComparator<PersistentMapEntry<K,V>> { 
+    static class PersistentMapComparator<K extends Comparable<? super K>, V> extends PersistentComparator<PersistentMapEntry<K,V>> {
         public int compareMembers(PersistentMapEntry<K,V> m1, PersistentMapEntry<K,V> m2) {
             return m1.key.compareTo(m2.key);
         }
 
+        @SuppressWarnings("unchecked")
         public int compareMemberWithKey(PersistentMapEntry<K,V> mbr, Object key) {
-            return mbr.key.compareTo(key);
+            return mbr.key.compareTo((K)key);
         }
     }
 

--- a/perst-core/src/main/java/org/garret/perst/impl/QueryImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/QueryImpl.java
@@ -6,8 +6,8 @@ import java.text.*;
 import java.util.Arrays.*;
 import org.garret.perst.*;
 
-class FilterIterator<T> extends IterableIterator<T> { 
-    Iterator     iterator;
+class FilterIterator<T> extends IterableIterator<T> {
+    Iterator<?>     iterator;
     Node         condition;
     QueryImpl<T> query;
     int[]        indexVar;
@@ -60,7 +60,7 @@ class FilterIterator<T> extends IterableIterator<T> {
         currObj = obj;
     }
 
-    FilterIterator(QueryImpl query, Iterator iterator, Node condition) { 
+    FilterIterator(QueryImpl query, Iterator<?> iterator, Node condition) {
         this.query = query;
         this.iterator = iterator;
         this.condition = condition;
@@ -4534,7 +4534,7 @@ public class QueryImpl<T> implements Query<T>
         return expr;
     }
 
-    final IterableIterator<T> filter(Iterator iterator, Node condition) { 
+    final IterableIterator<T> filter(Iterator<?> iterator, Node condition) {
         return new FilterIterator<T>(this, iterator, condition);
     }
 

--- a/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
@@ -1795,7 +1795,7 @@ public class StorageImpl implements Storage, StorageLifecycle, org.garret.perst.
         return new QueryImpl<T>(this);
     }
 
-    public Bitmap createBitmap(Iterator iterator) {
+    public Bitmap createBitmap(Iterator<?> iterator) {
         return new Bitmap(this, iterator);
     }
 
@@ -1839,11 +1839,11 @@ public class StorageImpl implements Storage, StorageLifecycle, org.garret.perst.
         return new PersistentHashImpl<K,V>(this, pageSize, loadFactor);
     }
 
-    public <K extends Comparable, V> IPersistentMap<K, V> createMap(Class keyType) {
+    public <K extends Comparable<? super K>, V> IPersistentMap<K, V> createMap(Class<K> keyType) {
         return createMap(keyType, 4);
     }
 
-    public <K extends Comparable, V> IPersistentMap<K, V> createMap(Class keyType, int initialSize) {
+    public <K extends Comparable<? super K>, V> IPersistentMap<K, V> createMap(Class<K> keyType, int initialSize) {
         if (!opened) {
             throw new StorageError(StorageError.STORAGE_NOT_OPENED);
         }

--- a/perst-core/src/main/java/org/garret/perst/rdf/VersionedStorage.java
+++ b/perst-core/src/main/java/org/garret/perst/rdf/VersionedStorage.java
@@ -283,7 +283,7 @@ public class VersionedStorage
     
     class ReferenceIterator implements Iterator {
         PropDef[]     defs;
-        Iterator[]    iterators;
+        Iterator<?>[]    iterators;
         int           pos;
         Thing         currThing;
         SearchKind    kind;
@@ -291,12 +291,12 @@ public class VersionedStorage
         DatabaseRoot  root;
         HashSet       visited;
 
-        public ReferenceIterator(DatabaseRoot root, PropDef[] defs, Iterator iterator, SearchKind kind, Date timestamp) {
+        public ReferenceIterator(DatabaseRoot root, PropDef[] defs, Iterator<?> iterator, SearchKind kind, Date timestamp) {
             this.root = root;
             this.defs = defs;
             this.kind = kind;
             this.timestamp = timestamp;
-            iterators = new Iterator[defs.length+1];
+            iterators = new Iterator<?>[defs.length+1];
             iterators[iterators.length-1] = iterator;
             visited = new HashSet();
             pos = iterators.length-1;
@@ -527,19 +527,19 @@ public class VersionedStorage
          root.exclusiveLock();
      }
 
-     static class SearchResult implements Iterator {
+    static class SearchResult implements Iterator {
          org.garret.perst.VersionHistory type;
          String         uri;
          NameVal[]      patterns;
          SearchKind     kind;
          Date           timestamp;
-         Iterator       iterator;
+         Iterator<?>       iterator;
          Thing          currThing;
          int            currVersion;
          Link           currHistory;
          DatabaseRoot   root;
          
-         public SearchResult(DatabaseRoot root, org.garret.perst.VersionHistory type, String uri, NameVal[] patterns, SearchKind kind, Date timestamp, Iterator iterator)
+         public SearchResult(DatabaseRoot root, org.garret.perst.VersionHistory type, String uri, NameVal[] patterns, SearchKind kind, Date timestamp, Iterator<?> iterator)
          {
              this.root = root;
              this.type = type;    

--- a/tst/TestMap.java
+++ b/tst/TestMap.java
@@ -65,7 +65,7 @@ public class TestMap {
         if (root == null) { 
             root = new Indices();
             root.strMap = db.createMap(String.class);
-            root.intMap = db.createMap(long.class);
+            root.intMap = db.createMap(Long.class);
             root.objMap = db.createMap(RecordKey.class);
             db.setRoot(root);
         }


### PR DESCRIPTION
## Summary
- add generic type bounds to `createMap` methods
- replace raw `Iterator` parameters with generics
- adjust tests for new generic map signature

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68ab79ff0a988330a4ad6d654459a781