### PR TITLE
Use Instant for version timestamps

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/Version.java
+++ b/perst-core/src/main/java/org/garret/perst/Version.java
@@ -1,6 +1,6 @@
 package org.garret.perst;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * Base class for version of versioned object. All versions are kept in version history.
@@ -60,7 +60,8 @@ public class Version extends PersistentResource
             newVersion.labels = new String[0];
             newVersion.id = null;
             newVersion.oid = 0;
-            newVersion.state = 0;            
+            newVersion.state = 0;
+            newVersion.date = null;
             return newVersion;
         } catch (CloneNotSupportedException x) { 
             // Could not happen sense we clone ourselves
@@ -84,7 +85,7 @@ public class Version extends PersistentResource
                     predecessor.successors.add(this);
                 }
             }
-            date = new Date();
+            date = Instant.now();
             history.versions.add(this);
             history.current = this;
             modify();
@@ -112,7 +113,7 @@ public class Version extends PersistentResource
      * Get date of version creation 
      * @return date when this version was created
      */
-    public Date getDate() { 
+    public Instant getDate() {
         return date;
     }
 
@@ -166,7 +167,7 @@ public class Version extends PersistentResource
         successors = storage.createLink(1);
         predecessors = storage.createLink(1);
         labels = new String[0];
-        date = new Date();
+        date = Instant.now();
         id = "1";
     }
 
@@ -191,7 +192,7 @@ public class Version extends PersistentResource
     private Link<Version> successors;
     private Link<Version> predecessors;
     private String[]      labels;
-    private Date          date;
+    private Instant       date;
     private String        id;
     VersionHistory        history;
 }

--- a/perst-core/src/main/java/org/garret/perst/VersionHistory.java
+++ b/perst-core/src/main/java/org/garret/perst/VersionHistory.java
@@ -1,5 +1,6 @@
 package org.garret.perst;
 
+import java.time.Instant;
 import java.util.*;
 
 /**
@@ -51,17 +52,17 @@ public class VersionHistory<V extends Version>  extends PersistentResource
      * @param timestamp deadline, if <code>null</code> then the latest version in version history will be returned
      * @return version with the largest timestamp less than or equal to specified <code>timestamp</code>
      */
-    public synchronized V getLatestBefore(Date timestamp) { 
-        if (timestamp == null) { 
+    public synchronized V getLatestBefore(Instant timestamp) {
+        if (timestamp == null) {
             return versions.get(versions.size()-1);
         }
         int l = 0, n = versions.size(), r = n;
-        long t = timestamp.getTime()+1;
-        while (l < r) { 
+        long t = timestamp.toEpochMilli()+1;
+        while (l < r) {
             int m = (l + r) >> 1;
-            if (versions.get(m).getDate().getTime() < t) { 
+            if (versions.get(m).getDate().toEpochMilli() < t) {
                 l = m + 1;
-            } else { 
+            } else {
                 r = m;
             }
         }
@@ -69,25 +70,41 @@ public class VersionHistory<V extends Version>  extends PersistentResource
     }
 
     /**
+     * @deprecated use {@link #getLatestBefore(Instant)} instead
+     */
+    @Deprecated
+    public synchronized V getLatestBefore(Date timestamp) {
+        return getLatestBefore(timestamp != null ? timestamp.toInstant() : null);
+    }
+
+    /**
      * Get earliest version after specified date
      * @param timestamp deadline, if <code>null</code> then root version will be returned
      * @return version with the smallest timestamp greater than or equal to specified <code>timestamp</code>
      */
-    public synchronized V getEarliestAfter(Date timestamp) { 
-        if (timestamp == null) { 
+    public synchronized V getEarliestAfter(Instant timestamp) {
+        if (timestamp == null) {
             return versions.get(0);
         }
         int l = 0, n = versions.size(), r = n;
-        long t = timestamp.getTime();
-        while (l < r) { 
+        long t = timestamp.toEpochMilli();
+        while (l < r) {
             int m = (l + r) >> 1;
-            if (versions.get(m).getDate().getTime() < t) { 
+            if (versions.get(m).getDate().toEpochMilli() < t) {
                 l = m + 1;
-            } else { 
+            } else {
                 r = m;
             }
         }
         return r < n ? versions.get(r) : null;
+    }
+
+    /**
+     * @deprecated use {@link #getEarliestAfter(Instant)} instead
+     */
+    @Deprecated
+    public synchronized V getEarliestAfter(Date timestamp) {
+        return getEarliestAfter(timestamp != null ? timestamp.toInstant() : null);
     }
 
 

--- a/perst-core/src/main/java/org/garret/perst/impl/ClassDescriptor.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/ClassDescriptor.java
@@ -2,6 +2,7 @@ package org.garret.perst.impl;
 import  org.garret.perst.*;
 import  java.lang.reflect.*;
 import  java.util.*;
+import  java.time.Instant;
 
 public final class ClassDescriptor extends Persistent { 
     ClassDescriptor   next;
@@ -243,7 +244,7 @@ public final class ClassDescriptor extends Persistent {
     {
         if (obj != null) {
             Class<?> cls = obj.getClass();
-            return obj instanceof IValue || obj instanceof Number || cls.isArray() || cls == Character.class || cls == Boolean.class || cls == Date.class || cls == String.class;
+            return obj instanceof IValue || obj instanceof Number || cls.isArray() || cls == Character.class || cls == Boolean.class || cls == Date.class || cls == Instant.class || cls == String.class;
         }
         return false;
     }
@@ -270,7 +271,7 @@ public final class ClassDescriptor extends Persistent {
             type = tpBoolean;
         } else if (c.isEnum()) {
             type = tpEnum;
-        } else if (c.equals(Date.class)) {
+        } else if (c.equals(Date.class) || c.equals(Instant.class)) {
             type = tpDate;
         } else if (IValue.class.isAssignableFrom(c)) {
             type = tpValue;

--- a/perst-core/src/main/java/org/garret/perst/impl/PersistentMapImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/PersistentMapImpl.java
@@ -1,6 +1,7 @@
 package org.garret.perst.impl;
 import  org.garret.perst.*;
 import  java.util.*;
+import  java.time.Instant;
 
 class PersistentMapImpl<K extends Comparable<? super K>, V> extends PersistentResource implements IPersistentMap<K, V>
 {
@@ -82,11 +83,11 @@ class PersistentMapImpl<K extends Comparable<? super K>, V> extends PersistentRe
             return ClassDescriptor.tpBoolean;
         } else if (c.isEnum()) {
             return ClassDescriptor.tpEnum;
-        } else if (c.equals(Date.class)) {
+        } else if (c.equals(Date.class) || c.equals(Instant.class)) {
             return ClassDescriptor.tpDate;
         } else if (IValue.class.isAssignableFrom(c)) {
             return ClassDescriptor.tpValue;
-        } else { 
+        } else {
             return ClassDescriptor.tpObject;
         }
     }

--- a/perst-core/src/main/java/org/garret/perst/rdf/VersionHistory.java
+++ b/perst-core/src/main/java/org/garret/perst/rdf/VersionHistory.java
@@ -1,5 +1,6 @@
 package org.garret.perst.rdf;
 
+import java.time.Instant;
 import java.util.*;
 import org.garret.perst.*;
 
@@ -36,14 +37,22 @@ public class VersionHistory extends Persistent {
     * @return The latest version in version history prior to the specified timestamp 
     * or null if no such version is found
     */
-    public Thing getLatestBefore(Date timestamp) {
-        for (int i = versions.size(); --i >= 0;) { 
+    public Thing getLatestBefore(Instant timestamp) {
+        for (int i = versions.size(); --i >= 0;) {
             Thing v = (Thing)versions.get(i);
-            if (v.timestamp.compareTo(timestamp) <= 0) { 
+            if (v.timestamp.toInstant().compareTo(timestamp) <= 0) {
                 return v;
             }
         }
         return null;
+    }
+
+    /**
+     * @deprecated use {@link #getLatestBefore(Instant)} instead
+     */
+    @Deprecated
+    public Thing getLatestBefore(Date timestamp) {
+        return timestamp == null ? getLatest() : getLatestBefore(timestamp.toInstant());
     }
     
    /** 
@@ -52,14 +61,22 @@ public class VersionHistory extends Persistent {
     * @param timestamp timestamp
     * @return The oldest version in version history released after the specified timestamp
     */
-    public Thing getOldestAfter(Date timestamp) {
-        for (int i = 0; i < versions.size(); i++) { 
+    public Thing getOldestAfter(Instant timestamp) {
+        for (int i = 0; i < versions.size(); i++) {
             Thing v = (Thing)versions.get(i);
-            if (v.timestamp.compareTo(timestamp) >= 0) { 
+            if (v.timestamp.toInstant().compareTo(timestamp) >= 0) {
                 return v;
             }
         }
-        return null;  
+        return null;
+    }
+
+    /**
+     * @deprecated use {@link #getOldestAfter(Instant)} instead
+     */
+    @Deprecated
+    public Thing getOldestAfter(Date timestamp) {
+        return timestamp == null ? null : getOldestAfter(timestamp.toInstant());
     }
 
    /** 
@@ -69,15 +86,23 @@ public class VersionHistory extends Persistent {
     * @param timestamp 
     * @return Version natching time criteria or null if not found
     */
-    public Thing getVersion(SearchKind kind, Date timestamp) {
-        if (kind == SearchKind.LatestVersion) { 
+    public Thing getVersion(SearchKind kind, Instant timestamp) {
+        if (kind == SearchKind.LatestVersion) {
             return getLatest();
         } else if (kind == SearchKind.LatestBefore) {
             return getLatestBefore(timestamp);
-        } else if (kind == SearchKind.OldestAfter) { 
+        } else if (kind == SearchKind.OldestAfter) {
             return getOldestAfter(timestamp);
-        } else { 
+        } else {
             throw new IllegalArgumentException("Invalid search kind " + kind + " for VersionHistory.GetVersion");
         }
+    }
+
+    /**
+     * @deprecated use {@link #getVersion(SearchKind, Instant)} instead
+     */
+    @Deprecated
+    public Thing getVersion(SearchKind kind, Date timestamp) {
+        return getVersion(kind, timestamp != null ? timestamp.toInstant() : null);
     }
 }


### PR DESCRIPTION
## Summary
- Replace `java.util.Date` with `Instant` for version timestamps
- Support `Instant` persistence by storing epoch milliseconds
- Add `Instant`-based lookup helpers for RDF version history

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68ab90ae2c0883308745c0ea5768c2b6