### PR TITLE
Add non-blocking and async read APIs with concurrency docs

### DIFF
--- a/doc/CONCURRENCY.md
+++ b/doc/CONCURRENCY.md
@@ -1,0 +1,25 @@
+# Concurrency utilities
+
+Two helper methods in `Storage` simplify reading objects while coordinating
+with concurrent writers.
+
+## `tryReadObject`
+
+```java
+MyClass obj = storage.tryReadObject(oid, MyClass.class);
+```
+
+`tryReadObject` immediately attempts to load the object. If another thread
+holds the write lock for the same object a `ConcurrentWriteException` is
+thrown.
+
+## `readObjectAsync`
+
+```java
+storage.readObjectAsync(oid, MyClass.class)
+       .thenAccept(obj -> System.out.println(obj));
+```
+
+`readObjectAsync` returns a `CompletableFuture`. When the object is not
+write-locked the future completes immediately. Otherwise it is enqueued and
+completed once the writer releases the lock.

--- a/perst-core/src/main/java/org/garret/perst/ConcurrentWriteException.java
+++ b/perst-core/src/main/java/org/garret/perst/ConcurrentWriteException.java
@@ -1,0 +1,11 @@
+package org.garret.perst;
+
+/**
+ * Thrown when a read operation is attempted on an object that is currently
+ * write locked by another thread.
+ */
+public class ConcurrentWriteException extends RuntimeException {
+    public ConcurrentWriteException(String message) {
+        super(message);
+    }
+}

--- a/perst-core/src/main/java/org/garret/perst/Storage.java
+++ b/perst-core/src/main/java/org/garret/perst/Storage.java
@@ -1,6 +1,7 @@
 package org.garret.perst;
 
 import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
 import org.garret.perst.fulltext.*;
 import org.garret.perst.impl.ThreadTransactionContext;
 
@@ -487,6 +488,28 @@ public interface Storage extends StorageLifecycle, TransactionManager, BackupSer
      * @param oid object oid
      */
     public void checkReadLock(int oid);
+
+    /**
+     * Attempt to read object without waiting for a concurrent writer to
+     * release the lock. If the object is currently write locked, a
+     * {@link ConcurrentWriteException} is thrown.
+     *
+     * @param oid object oid
+     * @param cls expected class of the object
+     * @return loaded object
+     * @throws ConcurrentWriteException if the object is locked for write
+     */
+    public <T> T tryReadObject(int oid, Class<T> cls) throws ConcurrentWriteException;
+
+    /**
+     * Asynchronously read object. If the object is currently write locked the
+     * returned future is completed once the writer releases the lock.
+     *
+     * @param oid object oid
+     * @param cls expected class of the object
+     * @return future completed with the loaded object
+     */
+    public <T> CompletableFuture<T> readObjectAsync(int oid, Class<T> cls);
 
     /**
      * Explicitely make object peristent. Usually objects are made persistent


### PR DESCRIPTION
## Summary
- Add `tryReadObject` and `readObjectAsync` to `Storage`/`StorageImpl` for non-blocking and asynchronous reads
- Introduce `ConcurrentWriteException` and pending read queue to resume deferred readers
- Document concurrency utilities and examples in `doc/CONCURRENCY.md`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68abce3ed59c83309afcbf99fd0e3629