### PR TITLE
Refactor root lookup and unswizzle generics

### DIFF
--- a/app/src/main/java/org/garret/perst/Storage.java
+++ b/app/src/main/java/org/garret/perst/Storage.java
@@ -83,7 +83,7 @@ public interface Storage {
      * in many other OODBMSes), you should create index and use it as root object.
      * @return root object or <code>null</code> if root is not specified (storage is not yet initialized)
      */
-    public <T> T getRoot();
+    public Object getRoot();
     
     /**
      * Set new storage root object.


### PR DESCRIPTION
## Summary
- Return storage root as `Object` and provide typed lookup to avoid unchecked casts
- Rework `unswizzle` to use `Class<?>` and reflection for collections, removing unsafe generics

## Testing
- `./gradlew compileJava --rerun-tasks`
- `./gradlew test` *(fails: 69 tests completed, 19 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68abe185eaa0833087b41e9aacd2bf6a