### PR TITLE
Improve generics for map and bitmap creation

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/Storage.java
+++ b/perst-core/src/main/java/org/garret/perst/Storage.java
@@ -314,7 +314,7 @@ public interface Storage {
      * @param iterator persistent objects iterator which is used to construct bitmap
      * @return bitmap for this selection
      */
-    public Bitmap createBitmap(Iterator iterator);
+    public Bitmap createBitmap(Iterator<?> iterator);
 
     /**
      * Create scalable persistent map.
@@ -323,7 +323,7 @@ public interface Storage {
      * @param keyType map key type
      * @return scalable map implementation
      */
-    public <K extends Comparable, V> IPersistentMap<K,V> createMap(Class keyType);
+    public <K extends Comparable<? super K>, V> IPersistentMap<K,V> createMap(Class<K> keyType);
 
     /**
      * Create scalable persistent map.
@@ -333,7 +333,7 @@ public interface Storage {
      * @param initialSize initial allocated size of the list
      * @return scalable map implementation
      */
-    public <K extends Comparable, V> IPersistentMap<K,V> createMap(Class keyType, int initialSize);
+    public <K extends Comparable<? super K>, V> IPersistentMap<K,V> createMap(Class<K> keyType, int initialSize);
 
     /**
      * Create new peristent set. Implementation of this set is based on B-Tree so it can efficiently


### PR DESCRIPTION
## Summary
- Tighten type parameters for Storage#createMap and Storage#createBitmap

## Testing
- `./gradlew test` *(fails: incompatible types in Transaction.java and missing beginThreadTransaction implementation in StorageImpl)*

------
https://chatgpt.com/codex/tasks/task_e_68abf4e0dcbc83308f4e69b95ccf5325