### PR TITLE
Use path string when opening GraphDatabase

### DIFF
--- a/perst-index-graph/src/main/java/biz/digitalindustry/db/graph/GraphDatabase.java
+++ b/perst-index-graph/src/main/java/biz/digitalindustry/db/graph/GraphDatabase.java
@@ -20,7 +20,7 @@ public class GraphDatabase implements GraphQueryEngine {
 
     public GraphDatabase(Path path) {
         db = StorageFactory.getInstance().createStorage();
-        db.open(path, Storage.DEFAULT_PAGE_POOL_SIZE);
+        db.open(path.toString(), Storage.DEFAULT_PAGE_POOL_SIZE);
 
         if (db.getRoot() == null) {
             Root root = new Root();


### PR DESCRIPTION
## Summary
- Use `path.toString()` when opening graph storage to match API expectations

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68b129caf1dc8330a52a74255a4d0a38