### PR TITLE
Refactor RegexIterator generics

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/impl/RegexIndexImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/RegexIndexImpl.java
@@ -219,14 +219,14 @@ public class RegexIndexImpl<T> extends AltBtreeFieldIndex<T> implements RegexInd
         }
     }
             
-    class RegexIterator<T> extends IterableIterator<T> implements PersistentIterator 
-    { 
+    class RegexIterator extends IterableIterator<T> implements PersistentIterator
+    {
         private Iterator<T> iterator;
         private T currObj;
         private String pattern;
         private Storage storage;
 
-        RegexIterator(Iterator<T> iterator, String pattern) { 
+        RegexIterator(Iterator<T> iterator, String pattern) {
             storage = getStorage();
             this.iterator = iterator;
             this.pattern = pattern;


### PR DESCRIPTION
## Summary
- Drop redundant type parameter from RegexIterator and rely on outer generic
- Ensure RegexIterator constructor uses typed Iterator and generic instantiations

## Testing
- `./gradlew :perst-core:compileJava --warning-mode=all`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b1fa2880c083308a0dcfbfddc2a79d