### PR TITLE
Improve type safety in JoinRegexIterator

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/impl/RegexIndexImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/RegexIndexImpl.java
@@ -293,7 +293,7 @@ public class RegexIndexImpl<T> extends AltBtreeFieldIndex<T> implements RegexInd
     class JoinRegexIterator extends IterableIterator<T> implements PersistentIterator
     {
         private Iterator<T>[] iterators;
-        private Object  currObj;
+        private T       currObj;
         private int     currOid;
         private String  pattern;
         private Storage storage;
@@ -326,10 +326,10 @@ public class RegexIndexImpl<T> extends AltBtreeFieldIndex<T> implements RegexInd
                             i = 0;
                         }
                     }
-                    Object obj = storage.getObjectByOID(oid1);
+                    T obj = ((Class<T>)RegexIndexImpl.this.getIndexedClass()).cast(storage.getObjectByOID(oid1));
                     String text = extractText(obj);
-                    if (match(text, pattern)) { 
-                        currObj = obj;         
+                    if (match(text, pattern)) {
+                        currObj = obj;
                         currOid = oid1;
                         return true;
                     }
@@ -342,7 +342,7 @@ public class RegexIndexImpl<T> extends AltBtreeFieldIndex<T> implements RegexInd
             if (!hasNext()) { 
                 throw new NoSuchElementException();
             }
-            T obj = (T)currObj;
+            T obj = currObj;
             currObj = null;
             return obj;
         }


### PR DESCRIPTION
## Summary
- Use generic type for `currObj` in `JoinRegexIterator`
- Cast fetched objects via the indexed class and return them without unchecked casts

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68b1fc64472883309bd7086937e6522f