### PR TITLE
Refine FieldIndex generics

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/FieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/FieldIndex.java
@@ -84,10 +84,10 @@ public interface FieldIndex<T> extends GenericIndex<T>
     public IterableIterator<T> queryByExample(T obj);
 
     /**
-     * Get class obejct objects which can be inserted in this index
-     * @return class specified in Storage.createFielIndex method
+     * Get class object of objects which can be inserted in this index
+     * @return class specified in Storage.createFieldIndex method
      */
-    public Class getIndexedClass();
+    public Class<T> getIndexedClass();
 
     /**
      * Get fields used as a key

--- a/perst-core/src/main/java/org/garret/perst/Storage.java
+++ b/perst-core/src/main/java/org/garret/perst/Storage.java
@@ -466,7 +466,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.UNSUPPORTED_INDEX_TYPE) exception if type of specified field is not supported by implementation
      */
-    public <T> FieldIndex<T> createFieldIndex(Class type, String fieldName, boolean unique);
+    public <T> FieldIndex<T> createFieldIndex(Class<T> type, String fieldName, boolean unique);
 
     /**
      * Create new field index
@@ -478,7 +478,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.UNSUPPORTED_INDEX_TYPE) exception if type of specified field is not supported by implementation
      */
-    public <T> FieldIndex<T> createFieldIndex(Class type, String fieldName, boolean unique, boolean caseInsensitive);
+    public <T> FieldIndex<T> createFieldIndex(Class<T> type, String fieldName, boolean unique, boolean caseInsensitive);
     /**
      * Create new field index
      * @param type objects of which type (or derived from which type) will be included in the index
@@ -490,7 +490,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.UNSUPPORTED_INDEX_TYPE) exception if type of specified field is not supported by implementation
      */
-    public <T> FieldIndex<T> createFieldIndex(Class type, String fieldName, boolean unique, boolean caseInsensitive, boolean thick);
+    public <T> FieldIndex<T> createFieldIndex(Class<T> type, String fieldName, boolean unique, boolean caseInsensitive, boolean thick);
 
     /**
      * Create new mutlifield index
@@ -501,7 +501,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.UNSUPPORTED_INDEX_TYPE) exception if type of specified field is not supported by implementation
      */
-    public <T> FieldIndex<T> createFieldIndex(Class type, String[] fieldNames, boolean unique);
+    public <T> FieldIndex<T> createFieldIndex(Class<T> type, String[] fieldNames, boolean unique);
 
     /**
      * Create new mutlifield index
@@ -513,7 +513,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.UNSUPPORTED_INDEX_TYPE) exception if type of specified field is not supported by implementation
      */
-    public <T> FieldIndex<T> createFieldIndex(Class type, String[] fieldNames, boolean unique, boolean caseInsensitive);
+    public <T> FieldIndex<T> createFieldIndex(Class<T> type, String[] fieldNames, boolean unique, boolean caseInsensitive);
 
     /**
      * Create new n-gram string field index for regular expression search
@@ -525,7 +525,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.INCOMPATIBLE_KEY_TYPE) exception if type of specified field is not string
      */
-    public <T> RegexIndex<T> createRegexIndex(Class type, String fieldName, boolean caseInsensitive, int nGrams);
+    public <T> RegexIndex<T> createRegexIndex(Class<T> type, String fieldName, boolean caseInsensitive, int nGrams);
 
     /**
      * Create new 3-gram case insensitive  string field index for regular expression search
@@ -535,7 +535,7 @@ public interface Storage {
      * @exception StorageError (StorageError.INDEXED_FIELD_NOT_FOUND) if there is no such field in specified class,<BR> 
      * StorageError(StorageError.INCOMPATIBLE_KEY_TYPE) exception if type of specified field is not string
      */
-    public <T> RegexIndex<T> createRegexIndex(Class type, String fieldName); 
+    public <T> RegexIndex<T> createRegexIndex(Class<T> type, String fieldName);
 
     /**
      * Create new index optimized for access by element position.

--- a/perst-core/src/main/java/org/garret/perst/impl/AltBtreeFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/AltBtreeFieldIndex.java
@@ -8,7 +8,7 @@ class AltBtreeFieldIndex<T> extends AltBtree<T> implements FieldIndex<T> {
     String className;
     String fieldName;
     long   autoincCount;
-    transient Class cls;
+    transient Class<T> cls;
     transient Field fld;
 
     AltBtreeFieldIndex() {}
@@ -21,7 +21,7 @@ class AltBtreeFieldIndex<T> extends AltBtree<T> implements FieldIndex<T> {
         }
     }
 
-    public Class getIndexedClass() { 
+    public Class<T> getIndexedClass() {
         return cls;
     }
 
@@ -29,13 +29,14 @@ class AltBtreeFieldIndex<T> extends AltBtree<T> implements FieldIndex<T> {
         return new Field[]{fld};
     }
 
+    @SuppressWarnings("unchecked")
     public void onLoad()
     {
-        cls = ClassDescriptor.loadClass(getStorage(), className);
+        cls = (Class<T>)ClassDescriptor.loadClass(getStorage(), className);
         locateField();
     }
 
-    AltBtreeFieldIndex(Class cls, String fieldName, boolean unique) {
+    AltBtreeFieldIndex(Class<T> cls, String fieldName, boolean unique) {
         this.cls = cls;
         this.unique = unique;
         this.fieldName = fieldName;
@@ -246,10 +247,10 @@ class AltBtreeFieldIndex<T> extends AltBtree<T> implements FieldIndex<T> {
     }
 }
 
-class AltBtreeCaseInsensitiveFieldIndex<T> extends AltBtreeFieldIndex<T> {    
+class AltBtreeCaseInsensitiveFieldIndex<T> extends AltBtreeFieldIndex<T> {
     AltBtreeCaseInsensitiveFieldIndex() {}
 
-    AltBtreeCaseInsensitiveFieldIndex(Class cls, String fieldName, boolean unique) {
+    AltBtreeCaseInsensitiveFieldIndex(Class<T> cls, String fieldName, boolean unique) {
         super(cls, fieldName, unique);
     }
 

--- a/perst-core/src/main/java/org/garret/perst/impl/AltBtreeMultiFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/AltBtreeMultiFieldIndex.java
@@ -9,33 +9,32 @@ class AltBtreeMultiFieldIndex<T> extends AltBtree<T> implements FieldIndex<T> {
     String   className;
     String[] fieldName;
 
-    transient Class   cls;
+    transient Class<T>   cls;
     transient Field[] fld;
 
     AltBtreeMultiFieldIndex() {}
     
-    AltBtreeMultiFieldIndex(Class cls, String[] fieldName, boolean unique) {
+    AltBtreeMultiFieldIndex(Class<T> cls, String[] fieldName, boolean unique) {
         this.cls = cls;
         this.unique = unique;
-        this.fieldName = fieldName;        
+        this.fieldName = fieldName;
         this.className = ClassDescriptor.getClassName(cls);
         locateFields();
-        type = ClassDescriptor.tpValue;        
+        type = ClassDescriptor.tpValue;
     }
 
-    private final void locateFields() 
+    private final void locateFields()
     {
-        Class scope = cls;
         fld = new Field[fieldName.length];
         for (int i = 0; i < fieldName.length; i++) {
             fld[i] = ClassDescriptor.locateField(cls, fieldName[i]);
-            if (fld[i] == null) { 
+            if (fld[i] == null) {
                 throw new StorageError(StorageError.INDEXED_FIELD_NOT_FOUND, className + "." + fieldName[i]);
             }
         }
     }
 
-    public Class getIndexedClass() { 
+    public Class<T> getIndexedClass() {
         return cls;
     }
 
@@ -43,9 +42,10 @@ class AltBtreeMultiFieldIndex<T> extends AltBtree<T> implements FieldIndex<T> {
         return fld;
     }
 
+    @SuppressWarnings("unchecked")
     public void onLoad()
     {
-        cls = ClassDescriptor.loadClass(getStorage(), className);
+        cls = (Class<T>)ClassDescriptor.loadClass(getStorage(), className);
         locateFields();
     }
 
@@ -235,10 +235,10 @@ class AltBtreeMultiFieldIndex<T> extends AltBtree<T> implements FieldIndex<T> {
     }
 }
 
-class AltBtreeCaseInsensitiveMultiFieldIndex<T> extends AltBtreeMultiFieldIndex<T> {    
+class AltBtreeCaseInsensitiveMultiFieldIndex<T> extends AltBtreeMultiFieldIndex<T> {
     AltBtreeCaseInsensitiveMultiFieldIndex() {}
 
-    AltBtreeCaseInsensitiveMultiFieldIndex(Class cls, String[] fieldNames, boolean unique) {
+    AltBtreeCaseInsensitiveMultiFieldIndex(Class<T> cls, String[] fieldNames, boolean unique) {
         super(cls, fieldNames, unique);
     }
 

--- a/perst-core/src/main/java/org/garret/perst/impl/BtreeFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/BtreeFieldIndex.java
@@ -22,7 +22,7 @@ class BtreeFieldIndex<T> extends Btree<T> implements FieldIndex<T> {
     String className;
     String fieldName;
     long   autoincCount;
-    transient Class cls;
+    transient Class<T> cls;
     transient Field fld;
 
     BtreeFieldIndex() {}
@@ -35,7 +35,7 @@ class BtreeFieldIndex<T> extends Btree<T> implements FieldIndex<T> {
         }
     }
 
-    public Class getIndexedClass() { 
+    public Class<T> getIndexedClass() {
         return cls;
     }
 
@@ -43,17 +43,18 @@ class BtreeFieldIndex<T> extends Btree<T> implements FieldIndex<T> {
         return new Field[]{fld};
     }
 
+    @SuppressWarnings("unchecked")
     public void onLoad()
     {
-        cls = ClassDescriptor.loadClass(getStorage(), className);
+        cls = (Class<T>)ClassDescriptor.loadClass(getStorage(), className);
         locateField();
     }
 
-    BtreeFieldIndex(Class cls, String fieldName, boolean unique) {
+    BtreeFieldIndex(Class<T> cls, String fieldName, boolean unique) {
         this(cls, fieldName, unique, 0);
     }
 
-    BtreeFieldIndex(Class cls, String fieldName, boolean unique, long autoincCount) {
+    BtreeFieldIndex(Class<T> cls, String fieldName, boolean unique, long autoincCount) {
         this.cls = cls;
         this.unique = unique;
         this.fieldName = fieldName;
@@ -265,14 +266,14 @@ class BtreeFieldIndex<T> extends Btree<T> implements FieldIndex<T> {
     }
 }
 
-class BtreeCaseInsensitiveFieldIndex<T>  extends BtreeFieldIndex<T> {    
+class BtreeCaseInsensitiveFieldIndex<T>  extends BtreeFieldIndex<T> {
     BtreeCaseInsensitiveFieldIndex() {}
 
-    BtreeCaseInsensitiveFieldIndex(Class cls, String fieldName, boolean unique) {
+    BtreeCaseInsensitiveFieldIndex(Class<T> cls, String fieldName, boolean unique) {
         super(cls, fieldName, unique);
     }
 
-    BtreeCaseInsensitiveFieldIndex(Class cls, String fieldName, boolean unique, long autoincCount) {
+    BtreeCaseInsensitiveFieldIndex(Class<T> cls, String fieldName, boolean unique, long autoincCount) {
         super(cls, fieldName, unique, autoincCount);
     }
 

--- a/perst-core/src/main/java/org/garret/perst/impl/BtreeMultiFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/BtreeMultiFieldIndex.java
@@ -30,18 +30,18 @@ class BtreeMultiFieldIndex<T> extends Btree<T> implements FieldIndex<T> {
     String[] fieldName;
     int[]    types;
 
-    transient Class   cls;
+    transient Class<T>   cls;
     transient Field[] fld;
 
     BtreeMultiFieldIndex() {}
     
-    BtreeMultiFieldIndex(Class cls, String[] fieldName, boolean unique) {
+    BtreeMultiFieldIndex(Class<T> cls, String[] fieldName, boolean unique) {
         this.cls = cls;
         this.unique = unique;
-        this.fieldName = fieldName;        
+        this.fieldName = fieldName;
         this.className = ClassDescriptor.getClassName(cls);
         locateFields();
-        type = ClassDescriptor.tpArrayOfByte;        
+        type = ClassDescriptor.tpArrayOfByte;
         types = new int[fieldName.length];
         for (int i = 0; i < types.length; i++) {
             types[i] = checkType(fld[i].getType());
@@ -59,7 +59,7 @@ class BtreeMultiFieldIndex<T> extends Btree<T> implements FieldIndex<T> {
         }
     }
 
-    public Class getIndexedClass() { 
+    public Class<T> getIndexedClass() {
         return cls;
     }
 
@@ -67,9 +67,10 @@ class BtreeMultiFieldIndex<T> extends Btree<T> implements FieldIndex<T> {
         return fld;
     }
 
+    @SuppressWarnings("unchecked")
     public void onLoad()
     {
-        cls = ClassDescriptor.loadClass(getStorage(), className);
+        cls = (Class<T>)ClassDescriptor.loadClass(getStorage(), className);
         locateFields();
     }
 
@@ -624,10 +625,10 @@ class BtreeMultiFieldIndex<T> extends Btree<T> implements FieldIndex<T> {
 }
 
 
-class BtreeCaseInsensitiveMultiFieldIndex<T> extends BtreeMultiFieldIndex<T> {    
+class BtreeCaseInsensitiveMultiFieldIndex<T> extends BtreeMultiFieldIndex<T> {
     BtreeCaseInsensitiveMultiFieldIndex() {}
 
-    BtreeCaseInsensitiveMultiFieldIndex(Class cls, String[] fieldNames, boolean unique) {
+    BtreeCaseInsensitiveMultiFieldIndex(Class<T> cls, String[] fieldNames, boolean unique) {
         super(cls, fieldNames, unique);
     }
 

--- a/perst-core/src/main/java/org/garret/perst/impl/RegexIndexImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/RegexIndexImpl.java
@@ -11,8 +11,8 @@ public class RegexIndexImpl<T> extends AltBtreeFieldIndex<T> implements RegexInd
     Index<Set<T>> inverseIndex;
 
     RegexIndexImpl() {}
-    
-    RegexIndexImpl(StorageImpl db, Class cls, String fieldName, boolean caseInsensitive, int nGrams) {
+
+    RegexIndexImpl(StorageImpl db, Class<T> cls, String fieldName, boolean caseInsensitive, int nGrams) {
         super(cls, fieldName, false);
         if (type != ClassDescriptor.tpString) { 
             throw new StorageError(StorageError.INCOMPATIBLE_KEY_TYPE);
@@ -326,7 +326,8 @@ public class RegexIndexImpl<T> extends AltBtreeFieldIndex<T> implements RegexInd
                             i = 0;
                         }
                     }
-                    T obj = ((Class<T>)RegexIndexImpl.this.getIndexedClass()).cast(storage.getObjectByOID(oid1));
+                    Class<T> cls = RegexIndexImpl.this.getIndexedClass();
+                    T obj = cls.cast(storage.getObjectByOID(oid1));
                     String text = extractText(obj);
                     if (match(text, pattern)) {
                         currObj = obj;

--- a/perst-core/src/main/java/org/garret/perst/impl/RndBtreeFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/RndBtreeFieldIndex.java
@@ -21,7 +21,7 @@ class RndBtreeFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
         }
     }
 
-    public Class getIndexedClass() { 
+    public Class<T> getIndexedClass() {
         return cls;
     }
 

--- a/perst-core/src/main/java/org/garret/perst/impl/RndBtreeMultiFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/RndBtreeMultiFieldIndex.java
@@ -23,19 +23,18 @@ class RndBtreeMultiFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
         type = ClassDescriptor.tpValue;        
     }
 
-    private final void locateFields() 
+    private final void locateFields()
     {
-        Class scope = cls;
         fld = new Field[fieldName.length];
         for (int i = 0; i < fieldName.length; i++) {
             fld[i] = ClassDescriptor.locateField(cls, fieldName[i]);
-            if (fld[i] == null) { 
+            if (fld[i] == null) {
                 throw new StorageError(StorageError.INDEXED_FIELD_NOT_FOUND, className + "." + fieldName[i]);
             }
         }
     }
 
-    public Class getIndexedClass() { 
+    public Class<T> getIndexedClass() {
         return cls;
     }
 

--- a/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
@@ -2077,19 +2077,19 @@ public class StorageImpl implements Storage {
         return new RtreeRn<T>(this);
     }
 
-    public <T> FieldIndex<T> createFieldIndex(Class type, String fieldName, boolean unique) {
+    public <T> FieldIndex<T> createFieldIndex(Class<T> type, String fieldName, boolean unique) {
         return this.<T>createFieldIndex(type, fieldName, unique, false);
     }
 
-    public <T> FieldIndex<T> createFieldIndex(Class type, String fieldName, boolean unique, boolean caseInsensitive) {
+    public <T> FieldIndex<T> createFieldIndex(Class<T> type, String fieldName, boolean unique, boolean caseInsensitive) {
         return this.<T>createFieldIndex(type, fieldName, unique, caseInsensitive, false);
     }
 
-    public <T> RegexIndex<T> createRegexIndex(Class type, String fieldName) {
+    public <T> RegexIndex<T> createRegexIndex(Class<T> type, String fieldName) {
         return createRegexIndex(type, fieldName, true, 3);
     }
 
-    public synchronized <T> RegexIndex<T> createRegexIndex(Class type, String fieldName, boolean caseInsensitive, int nGrams)
+    public synchronized <T> RegexIndex<T> createRegexIndex(Class<T> type, String fieldName, boolean caseInsensitive, int nGrams)
     {
          if (!opened) {
             throw new StorageError(StorageError.STORAGE_NOT_OPENED);
@@ -2097,7 +2097,7 @@ public class StorageImpl implements Storage {
          return new RegexIndexImpl<T>(this, type, fieldName, caseInsensitive, nGrams);
     }
 
-    public synchronized <T> FieldIndex<T> createFieldIndex(Class type, String fieldName, boolean unique, boolean caseInsensitive, boolean thick)
+    public synchronized <T> FieldIndex<T> createFieldIndex(Class<T> type, String fieldName, boolean unique, boolean caseInsensitive, boolean thick)
     {
         if (!opened) {
             throw new StorageError(StorageError.STORAGE_NOT_OPENED);
@@ -2117,11 +2117,11 @@ public class StorageImpl implements Storage {
         return index;
     }
 
-    public <T> FieldIndex<T> createFieldIndex(Class type, String[] fieldNames, boolean unique) {
+    public <T> FieldIndex<T> createFieldIndex(Class<T> type, String[] fieldNames, boolean unique) {
         return this.<T>createFieldIndex(type, fieldNames, unique, false);
     }
 
-    public synchronized <T> FieldIndex<T> createFieldIndex(Class type, String[] fieldNames, boolean unique, boolean caseInsensitive) {
+    public synchronized <T> FieldIndex<T> createFieldIndex(Class<T> type, String[] fieldNames, boolean unique, boolean caseInsensitive) {
         if (!opened) {
             throw new StorageError(StorageError.STORAGE_NOT_OPENED);
         }

--- a/perst-core/src/main/java/org/garret/perst/impl/ThickFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/ThickFieldIndex.java
@@ -8,7 +8,7 @@ class ThickFieldIndex<T> extends ThickIndex<T> implements FieldIndex<T>
 {
     String fieldName;
     int type;
-    Class cls;
+    Class<T> cls;
     transient Field fld;
     
     static Field locateField(Class cls, String fieldName) {
@@ -23,7 +23,7 @@ class ThickFieldIndex<T> extends ThickIndex<T> implements FieldIndex<T>
         fld = locateField(cls, fieldName);
     }
     
-    public Class getIndexedClass() { 
+    public Class<T> getIndexedClass() {
         return cls;
     }
 
@@ -38,11 +38,11 @@ class ThickFieldIndex<T> extends ThickIndex<T> implements FieldIndex<T>
 
     ThickFieldIndex() {}
 
-    ThickFieldIndex(StorageImpl db, Class cls, String fieldName) {
+    ThickFieldIndex(StorageImpl db, Class<T> cls, String fieldName) {
         this(db, cls, fieldName, locateField(cls, fieldName));
     }
 
-    ThickFieldIndex(StorageImpl db, Class cls, String fieldName, Field fld) {
+    ThickFieldIndex(StorageImpl db, Class<T> cls, String fieldName, Field fld) {
         super(db, fld.getType());
         type = Btree.checkType(fld.getType());
         this.cls = cls;
@@ -231,10 +231,10 @@ class ThickFieldIndex<T> extends ThickIndex<T> implements FieldIndex<T>
     }
 }
 
-class ThickCaseInsensitiveFieldIndex<T>  extends ThickFieldIndex<T> {    
+class ThickCaseInsensitiveFieldIndex<T>  extends ThickFieldIndex<T> {
     ThickCaseInsensitiveFieldIndex() {}
 
-    ThickCaseInsensitiveFieldIndex(StorageImpl db, Class cls, String fieldName) {
+    ThickCaseInsensitiveFieldIndex(StorageImpl db, Class<T> cls, String fieldName) {
         super(db, cls, fieldName);
     }
 


### PR DESCRIPTION
## Summary
- make `FieldIndex.getIndexedClass` return `Class<T>` for type safety
- propagate generic indexed class handling across index implementations
- update regex index iteration to use typed class casting

## Testing
- `./gradlew -q perst-core:compileJava` *(warnings: unchecked or unsafe operations)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fe3aa3188330a292ed83da5d5f1b