### PR TITLE
Make tryReadObject require class parameter

### DIFF
--- a/doc/CONCURRENCY.md
+++ b/doc/CONCURRENCY.md
@@ -13,6 +13,13 @@ MyClass obj = storage.tryReadObject(oid, MyClass.class);
 holds the write lock for the same object a `ConcurrentWriteException` is
 thrown.
 
+When the type of the object is not known in advance an overload without the
+class parameter can be used:
+
+```java
+Object obj = storage.tryReadObject(oid);
+```
+
 ## `readObjectAsync`
 
 ```java

--- a/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
@@ -3386,6 +3386,9 @@ public class StorageImpl implements Storage {
     }
 
     public synchronized <T> T tryReadObject(int oid, Class<T> cls) {
+        if (cls == null) {
+            throw new IllegalArgumentException("cls");
+        }
         if (lockManager.isWriteLocked(oid)) {
             throw new ConcurrentWriteException("Object " + oid + " is locked for write");
         }
@@ -3393,13 +3396,14 @@ public class StorageImpl implements Storage {
         if (obj == null || isRaw(obj)) {
             obj = loadStub(oid, obj, cls);
         }
-        if (cls != null) {
-            if (!cls.isInstance(obj)) {
-                throw new ClassCastException();
-            }
-            return cls.cast(obj);
+        if (!cls.isInstance(obj)) {
+            throw new ClassCastException();
         }
-        return (T)obj;
+        return cls.cast(obj);
+    }
+
+    public synchronized Object tryReadObject(int oid) {
+        return tryReadObject(oid, Object.class);
     }
 
     public <T> CompletableFuture<T> readObjectAsync(int oid, Class<T> cls) {


### PR DESCRIPTION
## Summary
- Enforce non-null class parameter in `tryReadObject` and add overload without class
- Document new overload for retrieving objects without known type

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68b1ffe58c148330a29669a4cef8cba2