### PR TITLE
Add timeout assertions for CountDownLatch in tests

### DIFF
--- a/perst-core/src/test/java/org/garret/perst/modes/ContinuousModeTest.java
+++ b/perst-core/src/test/java/org/garret/perst/modes/ContinuousModeTest.java
@@ -7,6 +7,7 @@ import org.junit.Assert;
 
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class ContinuousModeTest {
     static class Counter extends CVersion {
@@ -53,7 +54,12 @@ public class ContinuousModeTest {
             }).start();
         }
 
-        latch.await();
+        try {
+            Assert.assertTrue("Worker threads did not finish in time", latch.await(10, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Assert.fail("Interrupted while waiting for worker threads to finish");
+        }
         db.beginTransaction();
         Counter c = db.getSingleton(db.<Counter>find(Counter.class, "id", new Key(1)));
         Assert.assertEquals(threads * iterations, c.value);

--- a/perst-core/src/test/java/org/garret/perst/modes/SingleWriterModeTest.java
+++ b/perst-core/src/test/java/org/garret/perst/modes/SingleWriterModeTest.java
@@ -45,7 +45,12 @@ public class SingleWriterModeTest {
             }).start();
         }
 
-        latch.await();
+        try {
+            Assert.assertTrue("Worker threads did not finish in time", latch.await(10, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Assert.fail("Interrupted while waiting for worker threads to finish");
+        }
         writer.shutdown();
         writer.awaitTermination(10, TimeUnit.SECONDS);
 


### PR DESCRIPTION
## Summary
- add 10-second timeout checks for CountDownLatch waits in tests
- handle interruptions and report timeouts clearly

## Testing
- `./gradlew test` *(fails: cannot find symbol `NullFile` during test compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68b223605c7483308be165cd37b16a26