### PR TITLE
Fix object lookup and add thread locking

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/StorageImpl.java
@@ -3662,12 +3662,20 @@ public class StorageImpl implements Storage {
         return obj;
     }
 
+    @SuppressWarnings("unchecked")
     final synchronized <T> T lookupObject(int oid, Class<? extends T> cls) {
-        Object obj = lookupObject(oid);
-        if (!cls.isInstance(obj)) {
-            throw new ClassCastException();
+        checkReadLock(oid);
+        Object obj = objectCache.get(oid);
+        if (obj == null || isRaw(obj)) {
+            obj = loadStub(oid, obj, cls);
         }
-        return cls.cast(obj);
+        if (cls != null) {
+            if (!cls.isInstance(obj)) {
+                throw new ClassCastException();
+            }
+            return cls.cast(obj);
+        }
+        return (T)obj;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Avoid null ClassDescriptor by passing class hints to lookupObject
- Implement read/write locking for PersistentResource transactions

## Testing
- `./gradlew :perst-core:test --tests "org.garret.perst.StorageTest" --tests "org.garret.perst.StorageTestThreaded" --tests "org.garret.perst.modes.ContinuousModeTest" --rerun-tasks --info`


------
https://chatgpt.com/codex/tasks/task_e_68b28fe810248330bb8628d8d7a08f44