### PR TITLE
Use generics for compound keys

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/impl/AltBtreeCompoundIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/AltBtreeCompoundIndex.java
@@ -53,7 +53,9 @@ class AltBtreeCompoundIndex<T> extends AltBtree<T> implements Index<T> {
     }
 
     static class CompoundKey implements Comparable<CompoundKey>, IValue {
-        Object[] keys;
+        Comparable<?>[] keys;
+
+        @SuppressWarnings("unchecked")
         public int compareTo(CompoundKey c) {
             int n = keys.length < c.keys.length ? keys.length : c.keys.length;
             for (int i = 0; i < n; i++) {
@@ -65,7 +67,7 @@ class AltBtreeCompoundIndex<T> extends AltBtree<T> implements Index<T> {
             return 0;  // allow to compare part of the compound key
         }
 
-        CompoundKey(Object[] keys) {
+        CompoundKey(Comparable<?>[] keys) {
             this.keys = keys;
         }
     }
@@ -82,11 +84,11 @@ class AltBtreeCompoundIndex<T> extends AltBtree<T> implements Index<T> {
             throw new StorageError(StorageError.INCOMPATIBLE_KEY_TYPE);
         }
         Object[] keyComponents = (Object[])key.oval;
-        if ((!prefix && keyComponents.length != types.length) || keyComponents.length > types.length) { 
+        if ((!prefix && keyComponents.length != types.length) || keyComponents.length > types.length) {
             throw new StorageError(StorageError.INCOMPATIBLE_KEY_TYPE);
         }
         boolean isCopy = false;
-        for (int i = 0; i < keyComponents.length; i++) { 
+        for (int i = 0; i < keyComponents.length; i++) {
             int type = types[i];
             if (type == ClassDescriptor.tpObject || type == ClassDescriptor.tpBoolean) { 
                 if (!isCopy) { 
@@ -98,10 +100,12 @@ class AltBtreeCompoundIndex<T> extends AltBtree<T> implements Index<T> {
                 keyComponents[i] = (type == ClassDescriptor.tpObject)
                     ? (Object)Integer.valueOf(keyComponents[i] == null ? 0 : getStorage().getOid(keyComponents[i]))
                     : (Object)Byte.valueOf((byte)(((Boolean)keyComponents[i]).booleanValue() ? 1 : 0));
-                
+
             }
         }
-        return new Key(new CompoundKey(keyComponents), key.inclusion != 0);
+        Comparable[] comps = new Comparable[keyComponents.length];
+        System.arraycopy(keyComponents, 0, comps, 0, keyComponents.length);
+        return new Key(new CompoundKey(comps), key.inclusion != 0);
     }
             
     public ArrayList<T> getList(Key from, Key till) {

--- a/perst-core/src/main/java/org/garret/perst/impl/RndBtreeCompoundIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/RndBtreeCompoundIndex.java
@@ -54,22 +54,22 @@ class RndBtreeCompoundIndex<T> extends RndBtree<T> implements Index<T> {
         return keyTypes;
     }
 
-    static class CompoundKey implements Comparable, IValue {
-        Object[] keys;
+    static class CompoundKey implements Comparable<CompoundKey>, IValue {
+        Comparable<?>[] keys;
 
-        public int compareTo(Object o) { 
-            CompoundKey c = (CompoundKey)o;
-            int n = keys.length < c.keys.length ? keys.length : c.keys.length; 
-            for (int i = 0; i < n; i++) { 
-                int diff = ((Comparable)keys[i]).compareTo(c.keys[i]);
-                if (diff != 0) { 
+        @SuppressWarnings("unchecked")
+        public int compareTo(CompoundKey c) {
+            int n = keys.length < c.keys.length ? keys.length : c.keys.length;
+            for (int i = 0; i < n; i++) {
+                int diff = ((Comparable<Object>)keys[i]).compareTo(c.keys[i]);
+                if (diff != 0) {
                     return diff;
                 }
             }
             return 0;  // allow to compare part of the compound key
         }
 
-        CompoundKey(Object[] keys) { 
+        CompoundKey(Comparable<?>[] keys) {
             this.keys = keys;
         }
     }
@@ -86,10 +86,12 @@ class RndBtreeCompoundIndex<T> extends RndBtree<T> implements Index<T> {
             throw new StorageError(StorageError.INCOMPATIBLE_KEY_TYPE);
         }
         Object[] keyComponents = (Object[])key.oval;
-        if ((!prefix && keyComponents.length != types.length) || keyComponents.length > types.length) { 
+        if ((!prefix && keyComponents.length != types.length) || keyComponents.length > types.length) {
             throw new StorageError(StorageError.INCOMPATIBLE_KEY_TYPE);
         }
-        return new Key(new CompoundKey(keyComponents), key.inclusion != 0);
+        Comparable[] comps = new Comparable[keyComponents.length];
+        System.arraycopy(keyComponents, 0, comps, 0, keyComponents.length);
+        return new Key(new CompoundKey(comps), key.inclusion != 0);
     }
             
     public ArrayList<T> getList(Key from, Key till) {

--- a/perst-core/src/main/java/org/garret/perst/impl/RndBtreeMultiFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/RndBtreeMultiFieldIndex.java
@@ -57,21 +57,21 @@ class RndBtreeMultiFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
         locateFields();
     }
 
-    static class CompoundKey implements Comparable, IValue {
-        Object[] keys;
+    static class CompoundKey implements Comparable<CompoundKey>, IValue {
+        Comparable<?>[] keys;
 
-        public int compareTo(Object o) { 
-            CompoundKey c = (CompoundKey)o;
-            int n = keys.length < c.keys.length ? keys.length : c.keys.length; 
-            for (int i = 0; i < n; i++) { 
-                if (keys[i] != c.keys[i]) { 
-                    if (keys[i] == null) { 
+        @SuppressWarnings("unchecked")
+        public int compareTo(CompoundKey c) {
+            int n = keys.length < c.keys.length ? keys.length : c.keys.length;
+            for (int i = 0; i < n; i++) {
+                if (keys[i] != c.keys[i]) {
+                    if (keys[i] == null) {
                         return -1;
-                    } else if (c.keys[i] == null) { 
+                    } else if (c.keys[i] == null) {
                         return 1;
-                    } else { 
-                        int diff = ((Comparable)keys[i]).compareTo(c.keys[i]);
-                        if (diff != 0) { 
+                    } else {
+                        int diff = ((Comparable<Object>)keys[i]).compareTo(c.keys[i]);
+                        if (diff != 0) {
                             return diff;
                         }
                     }
@@ -80,7 +80,7 @@ class RndBtreeMultiFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
             return 0;  // allow to compare part of the compound key
         }
 
-        CompoundKey(Object[] keys) { 
+        CompoundKey(Comparable<?>[] keys) {
             this.keys = keys;
         }
     }
@@ -92,20 +92,23 @@ class RndBtreeMultiFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
         if (key.type != ClassDescriptor.tpArrayOfObject) { 
             throw new StorageError(StorageError.INCOMPATIBLE_KEY_TYPE);
         }
-        return new Key(new CompoundKey((Object[])key.oval), key.inclusion != 0);
+        Object[] components = (Object[])key.oval;
+        Comparable[] comps = new Comparable[components.length];
+        System.arraycopy(components, 0, comps, 0, components.length);
+        return new Key(new CompoundKey(comps), key.inclusion != 0);
     }
-            
+
     private Key extractKey(Object obj) {
-        Object[] keys = new Object[fld.length];
-        try { 
-            for (int i = 0; i < keys.length; i++) { 
+        Comparable[] keys = new Comparable[fld.length];
+        try {
+            for (int i = 0; i < keys.length; i++) {
                 Object val = fld[i].get(obj);
-                keys[i] = val;
-                if (!ClassDescriptor.isEmbedded(val)) { 
+                keys[i] = (Comparable)val;
+                if (!ClassDescriptor.isEmbedded(val)) {
                     getStorage().makePersistent(val);
                 }
             }
-        } catch (Exception x) { 
+        } catch (Exception x) {
             throw new StorageError(StorageError.ACCESS_VIOLATION, x);
         }
         return new Key(new CompoundKey(keys));


### PR DESCRIPTION
## Summary
- Replace raw `CompoundKey` comparisons with `Comparable<CompoundKey>` implementations
- Store compound key components in `Comparable<?>[]` and adjust constructors and key conversion logic

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b32c5199788330b0fd875fb8c76b4b