### PR TITLE
Use typed MultiFieldValue for multi-field index bulk insert operations

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/impl/AltBtreeMultiFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/AltBtreeMultiFieldIndex.java
@@ -127,23 +127,24 @@ class AltBtreeMultiFieldIndex<T> extends AltBtree<T> implements FieldIndex<T> {
     }
 
     public boolean addAll(Collection<? extends T> c) {
-        MultiFieldValue[] arr = new MultiFieldValue[c.size()];
+        @SuppressWarnings("unchecked")
+        MultiFieldValue<T>[] arr = (MultiFieldValue<T>[]) new MultiFieldValue[c.size()];
         Iterator<? extends T> e = c.iterator();
-        try { 
+        try {
             for (int i = 0; e.hasNext(); i++) {
                 T obj = e.next();
                 Comparable[] values = new Comparable[fld.length];
-                for (int j = 0; j < values.length; j++) { 
+                for (int j = 0; j < values.length; j++) {
                     values[j] = (Comparable)fld[j].get(obj);
                 }
-                arr[i] = new MultiFieldValue(obj, values);
+                arr[i] = new MultiFieldValue<>(obj, values);
             }
-        } catch (Exception x) { 
+        } catch (Exception x) {
             throw new StorageError(StorageError.ACCESS_VIOLATION, x);
         }
         Arrays.sort(arr);
         for (int i = 0; i < arr.length; i++) {
-            add((T)arr[i].obj);
+            add(arr[i].obj);
         }
         return arr.length > 0;
     }

--- a/perst-core/src/main/java/org/garret/perst/impl/BtreeMultiFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/BtreeMultiFieldIndex.java
@@ -5,21 +5,21 @@ import java.lang.reflect.*;
 import java.util.*;
 import java.util.ArrayList;
 
-class MultiFieldValue implements Comparable<MultiFieldValue> { 
+class MultiFieldValue<T> implements Comparable<MultiFieldValue<T>> {
     Comparable[] values;
-    Object       obj;
-    
-    public int compareTo(MultiFieldValue f) { 
+    T            obj;
+
+    public int compareTo(MultiFieldValue<T> f) {
         for (int i = 0; i < values.length; i++) {
             int diff = values[i].compareTo(f.values[i]);
-            if (diff != 0) { 
+            if (diff != 0) {
                 return diff;
             }
         }
         return 0;
     }
-    
-    MultiFieldValue(Object obj, Comparable[] values) { 
+
+    MultiFieldValue(T obj, Comparable[] values) {
         this.obj = obj;
         this.values = values;
     }
@@ -512,23 +512,24 @@ class BtreeMultiFieldIndex<T> extends Btree<T> implements FieldIndex<T> {
     }
 
     public boolean addAll(Collection<? extends T> c) {
-        MultiFieldValue[] arr = new MultiFieldValue[c.size()];
+        @SuppressWarnings("unchecked")
+        MultiFieldValue<T>[] arr = (MultiFieldValue<T>[]) new MultiFieldValue[c.size()];
         Iterator<? extends T> e = c.iterator();
-        try { 
+        try {
             for (int i = 0; e.hasNext(); i++) {
                 T obj = e.next();
                 Comparable[] values = new Comparable[fld.length];
-                for (int j = 0; j < values.length; j++) { 
+                for (int j = 0; j < values.length; j++) {
                     values[j] = (Comparable)fld[j].get(obj);
                 }
-                arr[i] = new MultiFieldValue(obj, values);
+                arr[i] = new MultiFieldValue<>(obj, values);
             }
-        } catch (Exception x) { 
+        } catch (Exception x) {
             throw new StorageError(StorageError.ACCESS_VIOLATION, x);
         }
         Arrays.sort(arr);
         for (int i = 0; i < arr.length; i++) {
-            add((T)arr[i].obj);
+            add(arr[i].obj);
         }
         return arr.length > 0;
     }

--- a/perst-core/src/main/java/org/garret/perst/impl/RndBtreeMultiFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/RndBtreeMultiFieldIndex.java
@@ -123,23 +123,24 @@ class RndBtreeMultiFieldIndex<T> extends RndBtree<T> implements FieldIndex<T> {
     }
 
     public boolean addAll(Collection<? extends T> c) {
-        MultiFieldValue[] arr = new MultiFieldValue[c.size()];
+        @SuppressWarnings("unchecked")
+        MultiFieldValue<T>[] arr = (MultiFieldValue<T>[]) new MultiFieldValue[c.size()];
         Iterator<? extends T> e = c.iterator();
-        try { 
+        try {
             for (int i = 0; e.hasNext(); i++) {
                 T obj = e.next();
                 Comparable[] values = new Comparable[fld.length];
-                for (int j = 0; j < values.length; j++) { 
+                for (int j = 0; j < values.length; j++) {
                     values[j] = (Comparable)fld[j].get(obj);
                 }
-                arr[i] = new MultiFieldValue(obj, values);
+                arr[i] = new MultiFieldValue<>(obj, values);
             }
-        } catch (Exception x) { 
+        } catch (Exception x) {
             throw new StorageError(StorageError.ACCESS_VIOLATION, x);
         }
         Arrays.sort(arr);
         for (int i = 0; i < arr.length; i++) {
-            add((T)arr[i].obj);
+            add(arr[i].obj);
         }
         return arr.length > 0;
     }


### PR DESCRIPTION
## Summary
- Introduced generic `MultiFieldValue<T>` with typed `obj` field and updated `Comparable` implementation.
- Switched multi-field index `addAll` methods to `MultiFieldValue<T>[]`, eliminating explicit casts when adding objects.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b32dfac3bc8330987468d50b698101