### PR TITLE
refactor: remove raw type usage in QueryTest

### DIFF
--- a/perst-core/src/test/java/org/garret/perst/QueryTest.java
+++ b/perst-core/src/test/java/org/garret/perst/QueryTest.java
@@ -92,7 +92,9 @@ public class QueryTest {
     @Test
     public void test00() {
         try{
-            query.select((Class)null, (Iterator)null, (String)null);
+            Class cls = null;
+            Iterator<Stored> iter = null;
+            query.select(cls, iter, (String)null);
             fail();
         }catch(NullPointerException e){
             // expected exception


### PR DESCRIPTION
## Summary
- eliminate raw Iterator and Class casts in QueryTest to avoid unchecked warnings

## Testing
- `./gradlew :perst-core:test --tests org.garret.perst.QueryTest`

------
https://chatgpt.com/codex/tasks/task_e_68b33290acd08330af74eb268b40968f