### PR TITLE
Refine entrySet generics in PersistentHashImpl

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/impl/PersistentHashImpl.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/PersistentHashImpl.java
@@ -484,29 +484,28 @@ class PersistentHashImpl<K, V> extends PersistentResource implements IPersistent
                     return false;
                 }
                 
-		public boolean contains(Object k) {
-                    Entry<K,V> e = (Entry<K,V>)k;
-                    if (e.getValue() != null) { 
+                public boolean contains(Map.Entry<? extends K, ? extends V> e) {
+                    if (e.getValue() != null) {
                         return e.getValue().equals(PersistentHashImpl.this.get(e.getKey()));
                     } else {
-                        return PersistentHashImpl.this.containsKey(e.getKey()) 
+                        return PersistentHashImpl.this.containsKey(e.getKey())
                             && PersistentHashImpl.this.get(e.getKey()) == null;
                     }
-		}
-	    };
-	}
-	return entrySet;
-    }   
+                }
+            };
+        }
+        return entrySet;
+    }
 
      
     public boolean equals(Object o) {
 	if (o == this) {
 	    return true;
         }
-	if (!(o instanceof Map)) {
-	    return false;
+        if (!(o instanceof Map)) {
+            return false;
         }
-	Map<K,V> t = (Map<K,V>) o;
+        Map<? extends K, ? extends V> t = (Map<? extends K, ? extends V>) o;
 	if (t.size() != size()) {
 	    return false;
         }


### PR DESCRIPTION
## Summary
- Replace `contains` entrySet parameter with a typed `Map.Entry` to avoid unchecked cast
- Use wildcard map types in `equals` and guard with `instanceof` before casting

## Testing
- `./gradlew :perst-core:compileJava --warning-mode all`
- `./gradlew :perst-core:test`


------
https://chatgpt.com/codex/tasks/task_e_68b50a39fd5c833084d1217f5a65d650