### PR TITLE
Use generics in ScalableSet

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/impl/ScalableSet.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/ScalableSet.java
@@ -67,27 +67,28 @@ class ScalableSet<T> extends PersistentCollection<T> implements IPersistentSet<T
         return r;
     }
 
-    public boolean add(T obj) { 
+    @SuppressWarnings("unchecked")
+    public boolean add(T obj) {
         if (link != null) {
             int i = binarySearch(obj);
             int n = link.size();
-            if (i < n && link.getRaw(i).equals(obj)) { 
+            if (i < n && link.getRaw(i).equals(obj)) {
                 return false;
             }
-            if (n == BTREE_THRESHOLD) { 
+            if (n == BTREE_THRESHOLD) {
                 set = getStorage().<T>createSet();
-                for (i = 0; i < n; i++) { 
-                    ((IPersistentSet)set).add(link.getRaw(i));
+                for (i = 0; i < n; i++) {
+                    ((IPersistentSet<T>) set).add((T) link.getRaw(i));
                 }
                 link = null;
                 modify();
                 set.add(obj);
-            } else { 
+            } else {
                 modify();
                 link.insert(i, obj);
             }
             return true;
-        } else { 
+        } else {
             return set.add(obj);
         }
     }


### PR DESCRIPTION
## Summary
- use `IPersistentSet<T>` for transfers from Link to Set and suppress warnings when populating

## Testing
- `./gradlew -p perst-core test`

------
https://chatgpt.com/codex/tasks/task_e_68b5c5ab691c83308a09caf56b6db435