### PR TITLE
Refine FieldValue generics in BtreeFieldIndex

### DIFF
--- a/perst-core/src/main/java/org/garret/perst/impl/BtreeFieldIndex.java
+++ b/perst-core/src/main/java/org/garret/perst/impl/BtreeFieldIndex.java
@@ -4,17 +4,18 @@ import  org.garret.perst.*;
 import java.lang.reflect.*;
 import java.util.*;
 
-class FieldValue implements Comparable<FieldValue> { 
-    Comparable value;
-    Object     obj;
-    
-    public int compareTo(FieldValue f) { 
+class FieldValue implements Comparable<FieldValue> {
+    Comparable<Object> value;
+    Object             obj;
+
+    public int compareTo(FieldValue f) {
         return value.compareTo(f.value);
     }
-    
-    FieldValue(Object obj, Object value) { 
+
+    @SuppressWarnings("unchecked")
+    FieldValue(Object obj, Object value) {
         this.obj = obj;
-        this.value = (Comparable)value;
+        this.value = (Comparable<Object>)value;
     }
 }
         


### PR DESCRIPTION
## Summary
- use `Comparable<Object>` instead of raw `Comparable` for `FieldValue` value field
- adjust constructor and `compareTo` to work with parameterized type

## Testing
- `./gradlew :perst-core:test`


------
https://chatgpt.com/codex/tasks/task_e_68b5c7da85c883309eade185139e4d69