### PR TITLE
Add Logback configuration for quieter Micronaut builds

### DIFF
--- a/perst-server/src/main/resources/logback.xml
+++ b/perst-server/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/perst-server/src/test/resources/logback-test.xml
+++ b/perst-server/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
## Summary
- configure Logback in `perst-server` to set root logging level to INFO with console appender
- add matching test Logback configuration so test runs stay quiet

## Testing
- `./gradlew build`
- `grep -i 'DEBUG' /tmp/build.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5d348fd008330b8f415c7fb4dc33d